### PR TITLE
Improved handling of error and warning message from SMT Solver

### DIFF
--- a/sys/solve/src/SMTInternal.hs
+++ b/sys/solve/src/SMTInternal.hs
@@ -38,10 +38,21 @@ import TxsDefs
 import TxsUtils
 
 cmdCVC4 :: CreateProcess
-cmdCVC4 = proc "cvc4-2017-04-27-win32-opt" ["--lang=smt", "--incremental", "--strings-exp", "--fmf-fun-rlv", "--uf-ss-fair", "--no-strings-std-ascii"] 
+cmdCVC4 = proc  "cvc4-2017-04-27-win32-opt" 
+                ["--lang=smt"
+                , "--incremental"
+                , "--strings-exp"
+                , "--fmf-fun-rlv"
+                , "--uf-ss-fair"
+                , "--no-strings-std-ascii"
+                ] 
 
 cmdZ3 :: CreateProcess
-cmdZ3 = proc "z3" ["-smt2","-in"]
+cmdZ3 = proc    "z3" 
+                ["-smt2"
+                ,"-in"
+             -- , "smt.string_solver=z3str3"      -- Z3 supports multiple string solvers
+                ]
 
 -- ----------------------------------------------------------------------------------------- --
 -- opens a connection to the SMTLIB interactive shell
@@ -282,8 +293,10 @@ put cmd  = do
 checkErrors :: Handle -> String -> IO ()
 checkErrors herr prefix  = do
     errors <- getAllInput herr
-    let pes = concatMap (prefix ++) (lines errors)
-    putStrLn pes
+    case errors of
+        []  -> return ()
+        _   -> let pes = unlines $ map (prefix ++) (lines errors) in
+                putStrLn pes
      
 -- ---------------------------------------------------------------------------------------- --
 -- read all available data from given handle


### PR DESCRIPTION
Additionally improved layout of
SMT commands for processes

added outcommented flag related to StringSolver which is added to Z3 4.5.1
we work with version 4.5.0 and above so flag is not always know yet!


----------------------------------------------------------------------------------------
Start Development Acceptance Test
End Development Acceptance Test
Start Development Acceptance Check
End Development Acceptance Check
Checking development acceptance test output for file 20170623_092156_DatOutput.datr
- TestCopyright:         PASS
- Test build:            PASS
- Torxakis build:        PASS
- SelfTests:             PASS
- TestExamps:
--- Stimulus Response Tests
----- StimulusResponse Test 1: PASS
----- StimulusResponse Test 2: PASS
----- StimulusResponse Test 3: PASS
----- StimulusResponse Test 4: PASS
----- StimulusResponse Test 5: PASS
--- CustomerOrders Tests
----- CustomersOrders Test: PASS
--- LuckyPeople Tests:
----- LuckyPeopleTest Test 1: PASS
----- LuckyPeopleTest Test 2: PASS
Checking finished