### PR TITLE
Fixed cabal files to show license correctly as BSD3.

### DIFF
--- a/sys/behaveenv/behaveenv.cabal
+++ b/sys/behaveenv/behaveenv.cabal
@@ -1,7 +1,7 @@
 name:                   behaveenv
 version:                0.1.7.0
 synopsis:               Behaviour Expressions for TorXakis
-license:                OtherLicense
+license:                BSD3
 license-file:           license.txt
 author:                 Jan Tretmans
                       , Pierre van de Laar

--- a/sys/cnect/cnect.cabal
+++ b/sys/cnect/cnect.cabal
@@ -1,7 +1,7 @@
 name:                   cnect
 version:                0.1.7.0
 synopsis:               Connections for TorXakis
-license:                OtherLicense
+license:                BSD3
 license-file:           license.txt
 author:                 Jan Tretmans
                       , Pierre van de Laar

--- a/sys/coreenv/coreenv.cabal
+++ b/sys/coreenv/coreenv.cabal
@@ -1,7 +1,7 @@
 name:                   coreenv
 version:                0.1.7.0
 synopsis:               CoreEnv of TorXakis
-license:                OtherLicense
+license:                BSD3
 license-file:           license.txt
 author:                 Jan Tretmans
                       , Pierre van de Laar

--- a/sys/serverenv/serverenv.cabal
+++ b/sys/serverenv/serverenv.cabal
@@ -1,7 +1,7 @@
 name:                   serverenv
 version:                0.1.7.0
 synopsis:               ServerEnv for TorXakis
-license:                OtherLicense
+license:                BSD3
 license-file:           license.txt
 author:                 Jan Tretmans
                       , Pierre van de Laar


### PR DESCRIPTION
Updated:
- behaveenv
- cnect
- coreenv
- serverenv

