### PR TITLE
cstrAnd and cstrOr work on Sets - so random generation can't control …

### DIFF
--- a/sys/defs/src/TxsDefs.hs
+++ b/sys/defs/src/TxsDefs.hs
@@ -39,6 +39,7 @@ module TxsDefs
 , cstrNot
 , cstrAnd
 , cstrOr
+, cstrImplies
 , cstrPredef
 , cstrError
 , view

--- a/sys/defs/src/TxsShow.hs
+++ b/sys/defs/src/TxsShow.hs
@@ -267,6 +267,10 @@ instance (PShow v) => PShow (ValExpr v)
       =  " ( LET " ++ pshow ve ++ " IN " ++ pshow vexp ++ " NI )"
     pshow (view -> Vequal vexp1 vexp2)
       =  "( " ++ pshow vexp1 ++ " == " ++ pshow vexp2 ++ " )"
+    pshow (view -> Vnot vexp)
+      =  "(not (" ++ pshow vexp ++ ") )"
+    pshow (view -> Vand vexps)
+      =  "(" ++ Utils.join " /\\ " (map pshow (Set.toList vexps)) ++ " )"
     pshow (view -> Vpredef _ fid vexps)
       =  if isSpecialOp fid
            then

--- a/sys/defs/src/ValExprImpls.hs
+++ b/sys/defs/src/ValExprImpls.hs
@@ -53,7 +53,9 @@ cstrVar :: v -> ValExpr v
 cstrVar v = ValExpr (Vvar v)
 
 cstrIte :: [ValExpr v] -> ValExpr v -> ValExpr v -> ValExpr v
-cstrIte cs tb fb = ValExpr (Vite cs tb fb)
+-- if (not b) then tb else fb == if b then fb else tb
+cstrIte [view -> Vnot n] tb fb  = ValExpr (Vite [n] fb tb)
+cstrIte cs tb fb                = ValExpr (Vite cs tb fb)
 
 cstrEnv :: VarEnv v v -> ValExpr v -> ValExpr v
 cstrEnv ve e = ValExpr (Venv ve e)
@@ -100,6 +102,8 @@ cstrNot :: ValExpr v -> ValExpr v
 cstrNot (view -> Vconst (Cbool True))       = cstrConst (Cbool False)
 cstrNot (view -> Vconst (Cbool False))      = cstrConst (Cbool True)
 cstrNot (view -> Vnot ve)                   = ve
+-- not (if cs then tb else fb) == if cs then not (tb) else not (fb)
+cstrNot (view -> Vite cs tb fb)             = ValExpr (Vite cs (cstrNot tb) (cstrNot fb))
 cstrNot ve                                  = ValExpr (Vnot ve)
 
 -- | Is ValExpr an And Expression?     

--- a/sys/solve/src/RandIncrementChoice.hs
+++ b/sys/solve/src/RandIncrementChoice.hs
@@ -25,6 +25,7 @@ import Control.Monad.State
 import qualified Data.Char as Char
 import qualified Data.Map  as Map
 import qualified Data.Set  as Set
+import qualified Data.String.Utils as Utils
 
 import SMT
 import SMTData
@@ -93,11 +94,14 @@ randomSolve p ((v,_):xs) i    | vsort v == sortId_Bool =
             Sat     -> randomSolve p xs i
             _       -> error "Unexpected SMT issue - previous solution is no longer valid - Bool"
     where
-        choicesFunc :: Variable v => v -> Bool -> Const -> [(Bool, ValExpr v)]
-        choicesFunc v' b (Cbool b')  = let cond = b == b' in
-                                         [ (cond,     cstrEqual (cstrVar v') (cstrConst (Cbool b)))
-                                         , (not cond, cstrEqual (cstrVar v') (cstrConst (Cbool (not b)))) 
-                                         ]
+        choicesFunc :: Variable v => v -> Bool -> Const -> SMT [(Bool, String)]
+        choicesFunc v' b (Cbool b')  = do
+                                         let cond = b == b' 
+                                         st <- valExprToString $ cstrEqual (cstrVar v') (cstrConst (Cbool b))
+                                         sf <- valExprToString $ cstrEqual (cstrVar v') (cstrConst (Cbool (not b)))
+                                         return [ (cond, st)
+                                                , (not cond, sf) 
+                                                ]
         choicesFunc _ _ _        = error "RandIncrementChoice: impossible choice - bool"
 
 randomSolve p ((v,_):xs) i    | vsort v == sortId_Int =
@@ -116,13 +120,15 @@ randomSolve p ((v,_):xs) i    | vsort v == sortId_Int =
             Sat     -> randomSolve p xs i
             _       -> error "Unexpected SMT issue - previous solution is no longer valid - Int"
     where
-        choicesFunc :: Variable v => v -> Int -> Const -> [(Bool, ValExpr v)]
-        choicesFunc v' r (Cint x)  = let r' = toInteger r
-                                         cond = x < r' 
-                                     in
-                                         [ (cond,     cstrFunc funcId_ltInt [cstrVar v', cstrConst (Cint r')]) 
-                                         , (not cond, cstrFunc funcId_geInt [cstrVar v', cstrConst (Cint r')]) 
-                                         ]
+        choicesFunc :: Variable v => v -> Int -> Const -> SMT [(Bool, String)]
+        choicesFunc v' r (Cint x)  = do
+                                        let r' = toInteger r
+                                            cond = x < r' 
+                                        st <- valExprToString $ cstrFunc funcId_ltInt [cstrVar v', cstrConst (Cint r')]
+                                        sf <- valExprToString $ cstrFunc funcId_geInt [cstrVar v', cstrConst (Cint r')]
+                                        return [ (cond, st) 
+                                               , (not cond, sf) 
+                                               ]
         choicesFunc _ _ _         = error "RandIncrementChoice: impossible choice - int"
 
 randomSolve p ((v,-123):xs) i    | vsort v == sortId_String =                 -- abuse depth to encode char versus string
@@ -137,16 +143,19 @@ randomSolve p ((v,-123):xs) i    | vsort v == sortId_String =                 --
             Sat     -> randomSolve p xs i
             _       -> error "Unexpected SMT issue - previous solution is no longer valid - char"
     where
-        choicesFunc :: Variable v => v -> Int -> Const -> [(Bool, ValExpr v)]
-        choicesFunc v' r (Cstring [c]) = let cond = r <= Char.ord c && Char.ord c <= r+127 in
-                                     [ (cond,     cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString r ++ "-" ++ toRegexString (r+127) ++ "]"))]) 
-                                     , (not cond, case r of
-                                                    0       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 128 ++ "-" ++ toRegexString 255 ++ "]"))]
-                                                    1       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 129 ++ "-" ++ toRegexString 255 ++ toRegexString 0 ++ "]"))]
-                                                    127     -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 255 ++ toRegexString 0 ++ "-" ++ toRegexString 126 ++ "]"))]
-                                                    _       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString (r+128) ++ "-" ++ toRegexString 255 ++ 
-                                                                                                                              toRegexString 0 ++ "-" ++ toRegexString (r-1) ++ "]"))]) 
-                                     ]
+        choicesFunc :: Variable v => v -> Int -> Const -> SMT [(Bool, String)]
+        choicesFunc v' r (Cstring [c]) = do
+                                            let cond = r <= Char.ord c && Char.ord c <= r+127
+                                            st <- valExprToString $ cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString r ++ "-" ++ toRegexString (r+127) ++ "]"))]
+                                            sf <- valExprToString $ case r of
+                                                                        0       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 128 ++ "-" ++ toRegexString 255 ++ "]"))]
+                                                                        1       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 129 ++ "-" ++ toRegexString 255 ++ toRegexString 0 ++ "]"))]
+                                                                        127     -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString 255 ++ toRegexString 0 ++ "-" ++ toRegexString 126 ++ "]"))]
+                                                                        _       -> cstrFunc funcId_strinre [cstrVar v', cstrConst (Cregex ("[" ++ toRegexString (r+128) ++ "-" ++ toRegexString 255 ++ 
+                                                                                                                                                  toRegexString 0 ++ "-" ++ toRegexString (r-1) ++ "]"))]
+                                            return [ (cond, st) 
+                                                   , (not cond, sf) 
+                                                   ]
         choicesFunc _ _ _         = error "RandIncrementChoice: impossible choice - char"
                                      
     
@@ -176,11 +185,14 @@ randomSolve p ((v,d):xs) i    | vsort v == sortId_String =
                                             _       -> error "Unexpected SMT issue - previous solution is no longer valid - String - l == 0"
             _              -> error "RandIncrementChoice: impossible constant - string"
     where
-        choicesFunc :: Variable v => v -> Int -> Const -> [(Bool, ValExpr v)]
-        choicesFunc v' r (Cstring s) = let cond = length s < r in
-                                     [ (cond,     cstrFunc funcId_ltInt [cstrFunc funcId_lenString [cstrVar v'], cstrConst (Cint (toInteger r))]) 
-                                     , (not cond, cstrFunc funcId_geInt [cstrFunc funcId_lenString [cstrVar v'], cstrConst (Cint (toInteger r))]) 
-                                     ]
+        choicesFunc :: Variable v => v -> Int -> Const -> SMT [(Bool, String)]
+        choicesFunc v' r (Cstring s) = do
+                                            let cond = length s < r
+                                            st <- valExprToString $ cstrFunc funcId_ltInt [cstrFunc funcId_lenString [cstrVar v'], cstrConst (Cint (toInteger r))]
+                                            sf <- valExprToString $ cstrFunc funcId_geInt [cstrFunc funcId_lenString [cstrVar v'], cstrConst (Cint (toInteger r))]
+                                            return [ (cond, st) 
+                                                   , (not cond, sf) 
+                                                   ]
         choicesFunc _ _ _         = error "RandIncrementChoice: impossible choice - string"
             
         
@@ -209,9 +221,6 @@ randomSolve p ((v,d):xs) i =
                     do
                         shuffledCstrs <- shuffleM cstrs
                         let (partA, partB) = splitAt (div (length cstrs) 2) shuffledCstrs
-                        -- TODO: the use of sets looses the ordering
-                        -- information that lists had. We need to re-introduce
-                        -- the randomization in the order of the `or` terms.
                         c <- randomSolveVar v (choicesFunc v partA partB)
                         case c of
                             Cstr{cstrId = cid}  -> 
@@ -235,28 +244,35 @@ randomSolve p ((v,d):xs) i =
                                     Nothing                 -> error "RandIncrementChoice: value not found - ADT - n"                        
                             _                   -> error "RandIncrementChoice: impossible constant - ADT - n"
     where
-        choicesFunc :: Variable v => v -> [(CstrId, CstrDef)] -> [(CstrId, CstrDef)] -> Const -> [(Bool, ValExpr v)]
+        choicesFunc :: Variable v => v -> [(CstrId, CstrDef)] -> [(CstrId, CstrDef)] -> Const -> SMT [(Bool, String)]
         choicesFunc v' partA partB Cstr{cstrId = cId} = 
-            let cond = Map.member cId (Map.fromList partA) in
-                                 [ (cond, cstrOr $ Set.fromList (map (\(_,CstrDef isC _) -> cstrFunc isC [cstrVar v']) partA) )
-                                 , (not cond, cstrOr $ Set.fromList (map (\(_,CstrDef isC _) -> cstrFunc isC [cstrVar v']) partB) )
-                                 ]
+            do
+                let cond = Map.member cId (Map.fromList partA)
+                lA <- mapM (\(_,CstrDef isC _) -> valExprToString $ cstrFunc isC [cstrVar v']) partA
+                lB <- mapM (\(_,CstrDef isC _) -> valExprToString $ cstrFunc isC [cstrVar v']) partB
+                return [ (cond, case lA of
+                                    [a] -> a
+                                    _   -> "(or " ++ Utils.join " " lA ++ ") ")
+                       , (not cond, case lB of
+                                        [b] -> b
+                                        _   -> "(or " ++ Utils.join " " lB ++ ") ")
+                       ]
         choicesFunc _ _ _ _        = error "RandIncrementChoice: impossible choice - string"
 
 
 -- Find random solution for variable, using the different choices
-randomSolveVar :: (Variable v) => v -> (Const -> [(Bool, ValExpr v)]) -> SMT Const
+randomSolveVar :: (Variable v) => v -> (Const -> SMT [(Bool, String)]) -> SMT Const
 randomSolveVar v choicesFunc = do
     sol <- getSolution [v]
     case Map.lookup v sol of
         Just c  -> do
-                        let choices = choicesFunc c
+                        choices <- choicesFunc c
                         shuffledChoices <- shuffleM choices
                         case head shuffledChoices of
                             (True , _)          -> return c
                             (False, assertion)  -> do
                                                         push
-                                                        addAssertions [assertion]
+                                                        SMT.put $ "(assert " ++ assertion ++ ")"
                                                         sat <- getSolvable
                                                         case sat of 
                                                             Sat -> do

--- a/sys/solve/src/RandTrueBins.hs
+++ b/sys/solve/src/RandTrueBins.hs
@@ -34,6 +34,7 @@ import Control.Monad.State
 import qualified Data.Char as Char
 import qualified Data.Map  as Map
 import qualified Data.Set  as Set
+import qualified Data.String.Utils as Utils
 
 import SMT
 import SMTData
@@ -64,7 +65,12 @@ randValExprsSolveTrueBins p freevars exprs  =
         push
         addDeclarations freevars
         randvars <- foldr combine (return []) freevars
-        addAssertions randvars
+        case randvars of
+            [randvar] -> SMT.put $ "(assert " ++ randvar ++ ")"
+            _         -> do
+                            shuffledList <- shuffleM randvars
+                            SMT.put $ "(assert (and " ++ Utils.join " " shuffledList ++ ") )"
+        
         addAssertions exprs
         sat <- getSolvable
         sp <- case sat of 
@@ -79,11 +85,11 @@ randValExprsSolveTrueBins p freevars exprs  =
         lift $ hPutStrLn stderr "TXS RandTrueBins randValExprsSolveTrueBins: Not all added constraints are Bool\n"
         return UnableToSolve
     where
-        combine :: (Variable v) => v -> SMT [ValExpr v] -> SMT [ValExpr v]
+        combine :: (Variable v) => v -> SMT [String] -> SMT [String]
         combine vid sexprs = do
             expr <- randomValue p (vsort vid) (cstrVar vid) (maxDepth p)
-            exprs' <- sexprs
-            return $ expr : exprs'
+            exprs <- sexprs
+            return $ (expr:exprs)
 
 -- -----------------------------------------------------------------
 nextFunction :: ParamTrueBins -> Integer -> Integer
@@ -108,13 +114,12 @@ nextExponent n = n * n
 -- --------------------------------------
 -- randomly draw boolean value
 -- -----------------------------------------
-trueBool :: (Variable v) => ValExpr v -> SMT (ValExpr v) 
+trueBool :: (Variable v) => ValExpr v -> SMT String
 trueBool expr = do
     let orList = [expr, cstrNot expr]
     shuffledOrList <- shuffleM orList
-    -- TODO: the use of sets looses the ordering information that lists had. We
-    -- need to re-introduce the randomization in the order of the `or` terms.
-    return $ cstrOr (Set.fromList shuffledOrList) 
+    stringList <- mapM valExprToString shuffledOrList
+    return $ "(or " ++ Utils.join " " stringList ++ ") "
     
 -- -----------------------------------------------------------------
 -- randomly draw values from multiple bins
@@ -134,7 +139,7 @@ toBins :: (Variable v) => ValExpr v -> [Integer] -> [ValExpr v]
 toBins v (x1:x2:xs) = cstrAnd ( Set.fromList [cstrFunc funcId_leInt [cstrConst (Cint x1), v], cstrFunc funcId_ltInt [v, cstrConst (Cint x2)] ] ) : toBins v (x2:xs)
 toBins _ _ = []
                 
-trueBins :: (Variable v) => ValExpr v -> Int -> (Integer -> Integer) -> SMT (ValExpr v)
+trueBins :: (Variable v) => ValExpr v -> Int -> (Integer -> Integer) -> SMT String
 trueBins v n nxt = do
     neg <- values n nxt
     pos <- values n nxt
@@ -143,7 +148,8 @@ trueBins v n nxt = do
                   cstrFunc funcId_leInt [cstrConst (Cint (last binSamples) ), v] ] 
                  ++ toBins v binSamples
     shuffledOrList <- shuffleM orList
-    return $ cstrOr (Set.fromList shuffledOrList)
+    stringList <- mapM valExprToString shuffledOrList
+    return $ "(or " ++ Utils.join " " stringList ++ ") "
     
 -- -----------------------------------------------------------------
 -- enable randomly draw strings
@@ -194,20 +200,22 @@ trueCharsRegexes n | n > 0  = do
     return $ hd:tl
 trueCharsRegexes n          = error ("trueCharsRegexes: Illegal argument n = " ++ show n)
     
-trueStringLength :: (Variable v) => Int -> ValExpr v -> SMT (ValExpr v)
+trueStringLength :: (Variable v) => Int -> ValExpr v -> SMT String
 trueStringLength n v = do
     let exprs = map (\m -> cstrEqual (cstrFunc funcId_lenString [v]) (cstrConst (Cint (toInteger m)))) [0..n] ++ [cstrFunc funcId_gtInt [cstrFunc funcId_lenString [v], cstrConst (Cint (toInteger n))]]
-    sexprs <- shuffleM exprs
-    return $ cstrOr (Set.fromList sexprs)
-
-trueStringRegex :: (Variable v) => Int -> ValExpr v -> SMT (ValExpr v)
+    shuffledOrList <- shuffleM exprs
+    stringList <- mapM valExprToString shuffledOrList
+    return $ "(or " ++ Utils.join " " stringList ++ ") "
+    
+trueStringRegex :: (Variable v) => Int -> ValExpr v -> SMT String
 trueStringRegex n v = do
     regexes <- trueCharsRegexes n
     sregexes <- shuffleM (regexes ++ [range ++ "{"++ show (n+1) ++ ",}"])               -- Performance gain in problem solver? Use string length for length 0 and greater than n
-    let sexprs = map (\regex -> cstrFunc funcId_strinre [v, cstrConst (Cregex regex)]) sregexes
-    return $ cstrOr (Set.fromList sexprs)
+    let shuffledOrList = map (\regex -> cstrFunc funcId_strinre [v, cstrConst (Cregex regex)]) sregexes
+    stringList <- mapM valExprToString shuffledOrList
+    return $ "(or " ++ Utils.join " " stringList ++ ") "
     
-trueString :: (Variable v) => ParamTrueBins -> ValExpr v -> SMT (ValExpr v)
+trueString :: (Variable v) => ParamTrueBins -> ValExpr v -> SMT String
 trueString p v = 
     case stringMode p of
         Regex   -> trueStringRegex  (stringLength p) v
@@ -222,8 +230,8 @@ lookupConstructors sid  =  do
      tdefs <- gets txsDefs
      return [ def | def@(CstrId{ cstrsort = sid' } , _) <- Map.toList (cstrDefs tdefs), sid == sid']
 
-randomValue :: (Variable v) => ParamTrueBins -> SortId -> ValExpr v -> Int -> SMT (ValExpr v)
-randomValue _ _sid _expr 0 = return $ cstrConst (Cbool True)
+randomValue :: (Variable v) => ParamTrueBins -> SortId -> ValExpr v -> Int -> SMT String
+randomValue _ _sid _expr 0 = return "true"
 randomValue p sid expr n | n > 0 = 
     case sid of
         x | x == sortId_Bool   -> trueBool expr
@@ -233,22 +241,28 @@ randomValue p sid expr n | n > 0 =
                 cstrs <- lookupConstructors sid
                 orList <- processConstructors cstrs expr
                 shuffledOrList <- shuffleM orList
-                return (cstrOr (Set.fromList shuffledOrList))
+                return $ "(or " ++ Utils.join " " shuffledOrList ++ ") "
             where
-                processConstructors :: (Variable v) => [(CstrId, CstrDef)] -> ValExpr v -> SMT [ValExpr v]
+                processConstructors :: (Variable v) => [(CstrId, CstrDef)] -> ValExpr v -> SMT [String]
                 processConstructors [] _ = return []
                 processConstructors (x:xs) expr' = do
                     r <- processConstructor x expr'
                     rr <- processConstructors xs expr'
                     return (r:rr)
         
-                processConstructor :: (Variable v) => (CstrId,CstrDef) -> ValExpr v -> SMT (ValExpr v)
-                processConstructor (cid,CstrDef isX []) expr' = return $ cstrFunc isX [expr']
+                processConstructor :: (Variable v) => (CstrId,CstrDef) -> ValExpr v -> SMT String
+                processConstructor (cid,CstrDef isX []) expr' = valExprToString $ cstrFunc isX [expr']
                 processConstructor (cid,CstrDef isX accessors) expr' = do
+                    cstr <- valExprToString $ cstrFunc isX [expr']
                     args <- processArguments (zip (cstrargs cid) accessors) expr'
-                    return $ cstrAnd (Set.fromList (cstrFunc isX [expr'] : args))
-                
-                processArguments ::  (Variable v) => [(SortId,FuncId)] -> ValExpr v -> SMT [ValExpr v]
+                    case args of
+                        [arg]   -> return $ "(ite " ++ cstr ++ " " ++ arg ++ " false) "
+                        _       -> do
+                                    shuffledAndList <- shuffleM args
+                                    return $ "(ite " ++ cstr ++ " (and " ++ Utils.join " " shuffledAndList ++ ") false) "
+
+                    
+                processArguments ::  (Variable v) => [(SortId,FuncId)] -> ValExpr v -> SMT [String]
                 processArguments [] _ =  return []
                 processArguments ((sid',fid):xs) expr' = do
                     r <- randomValue p sid' (cstrFunc fid [expr']) (n-1)

--- a/sys/solve/src/SMT.hs
+++ b/sys/solve/src/SMT.hs
@@ -13,16 +13,18 @@ module SMT
 -- ----------------------------------------------------------------------------------------- --
 -- export
 
-( openSolver        -- :: SMT String
-, close             -- :: SMT ()
-, push              -- :: SMT ()
-, pop               -- :: SMT ()
-, createSMTEnv      -- :: SMTEnv
-, addDefinitions    -- :: SMT ()
-, addDeclarations   -- :: (Variable v) => [v] -> SMT()
-, addAssertions     -- :: (Variable v) => [ValExpr v] -> SMT ()
-, getSolvable       -- :: SMT SolvableProblem
-, getSolution       -- :: (Variable v) => [v] -> SMT (Solution v)
+( createSMTEnv
+, openSolver
+, close
+, addDefinitions
+, addDeclarations
+, addAssertions
+, getSolvable
+, getSolution
+, push
+, pop
+, put
+, valExprToString
 
 , cmdCVC4
 , cmdZ3

--- a/sys/solve/test/TestConstraint.hs
+++ b/sys/solve/test/TestConstraint.hs
@@ -193,7 +193,7 @@ testBoolFalse :: SMT()
 testBoolFalse = testTemplateValue TxsDefs.empty [sortId_Bool] createAssertions check
     where
         createAssertions :: [VarId] -> [VExpr]
-        createAssertions [v] = [cstrFunc funcId_not [cstrVar v]]
+        createAssertions [v] = [cstrNot (cstrVar v)]
         createAssertions _   = error "One variable in problem"
         
         check :: [Const] -> SMT()
@@ -326,9 +326,9 @@ testConditionalIntInstances = testTemplateValue conditionalIntDef
                                                 check3Different
     where
         createAssertions :: [VarId] -> [VExpr]
-        createAssertions [v1,v2,v3]    = [ cstrFunc funcId_not [cstrEqual (cstrVar v1) (cstrVar v2)]
-                                         , cstrFunc funcId_not [cstrEqual (cstrVar v2) (cstrVar v3)]
-                                         , cstrFunc funcId_not [cstrEqual (cstrVar v1) (cstrVar v3)]
+        createAssertions [v1,v2,v3]    = [ cstrNot (cstrEqual (cstrVar v1) (cstrVar v2))
+                                         , cstrNot (cstrEqual (cstrVar v2) (cstrVar v3))
+                                         , cstrNot (cstrEqual (cstrVar v1) (cstrVar v3))
                                          ]
         createAssertions _   = error "Three variables in problem"
         
@@ -355,9 +355,9 @@ testNestedConstructor = do
         conditionalPairSortId = SortId "ConditionalPair" 9630
         
         createAssertions :: [VarId] -> [VExpr]
-        createAssertions [v1,v2,v3]    = [ cstrFunc funcId_not [cstrEqual (cstrVar v1) (cstrVar v2)]
-                                         , cstrFunc funcId_not [cstrEqual (cstrVar v2) (cstrVar v3)]
-                                         , cstrFunc funcId_not [cstrEqual (cstrVar v1) (cstrVar v3)]
+        createAssertions [v1,v2,v3]    = [ cstrNot (cstrEqual (cstrVar v1) (cstrVar v2))
+                                         , cstrNot (cstrEqual (cstrVar v2) (cstrVar v3))
+                                         , cstrNot (cstrEqual (cstrVar v1) (cstrVar v3))
                                          ]
         createAssertions _   = error "Three variables in problem"
             

--- a/sys/value/src/Eval.hs
+++ b/sys/value/src/Eval.hs
@@ -277,40 +277,9 @@ evalSSB (FuncId nm uid args srt) vexps  =  do
      ; ( "fromXml",     [v1]    ) -> do Cstring s <- eval v1
                                         tdefs <- gets IOB.tdefs
                                         return $ constFromXml tdefs sortId_Bool s
-     ; ( "<>",          [v1,v2] ) -> do b1 <- txs2bool v1
-                                        b2 <- txs2bool v2
-                                        bool2txs $ b1 /= b2
-     ; ( "not",         [v1]    ) -> do b1 <- txs2bool v1
-                                        bool2txs $ not b1
-     ; ( "/\\",         [v1,v2] ) -> do b1 <- txs2bool v1
-                                        if b1 
-                                        then do
-                                            b2 <- txs2bool v2
-                                            bool2txs b2
-                                        else 
-                                            bool2txs False 
-     ; ( "\\/",         [v1,v2] ) -> do b1 <- txs2bool v1
-                                        if b1 
-                                            then bool2txs True
-                                            else do
-                                                b2 <- txs2bool v2
-                                                bool2txs b2
-     ; ( "\\|/",        [v1,v2] ) -> do b1 <- txs2bool v1
-                                        b2 <- txs2bool v2
-                                        bool2txs $ b1 /= b2
-     ; ( "=>",          [v1,v2] ) -> do b1 <- txs2bool v1
-                                        if b1 
-                                            then do
-                                                b2 <- txs2bool v2
-                                                bool2txs b2
-                                            else 
-                                                bool2txs True
-     ; ( "<=>",         [v1,v2] ) -> do b1 <- txs2bool v1
-                                        b2 <- txs2bool v2
-                                        bool2txs $ b1 == b2
-     ; _                          -> do IOB.putMsgs [ EnvData.TXS_CORE_SYSTEM_ERROR
-                                                      $ "evalSSB: standard Bool opn" ]
-                                        return $ Cerror ""
+     ; ( s, _ )                   -> do IOB.putMsgs [ EnvData.TXS_CORE_SYSTEM_ERROR
+                                                      $ "evalSSB: unknown standard Bool opn - " ++ s ]
+                                        return $ Cerror ("unknown " ++ s)
      }
 
 


### PR DESCRIPTION
…order of elements when using ValExprs anymore

Randomization explicitly write their own SMT strings
Also solved other issues cause by #48