### PR TITLE
removed dependency on text-show

### DIFF
--- a/sys/behave/behave.cabal
+++ b/sys/behave/behave.cabal
@@ -29,7 +29,7 @@ library
   build-depends:        base
                       , containers
                       , mtl
-                      , text-show
+                      , text
 
                       , behavedefs
                       , behaveenv
@@ -67,10 +67,11 @@ test-suite behave-test
   build-depends:       base
                      , containers
                      , mtl
+                     , text
+
                      , HUnit
                      , MissingH
                      , text
-                     , text-show
                      
                      , behavedefs
                      , behaveenv

--- a/sys/behave/src/Expand.hs
+++ b/sys/behave/src/Expand.hs
@@ -31,11 +31,11 @@ where
 import           Control.Arrow
 import           Control.Monad.State
 import           Data.Monoid
-import           TextShow
 
 import qualified Data.List           as List
 import qualified Data.Map            as Map
 import qualified Data.Set            as Set
+import qualified Data.Text           as T
 
 import qualified EnvBTree            as IOB
 import qualified EnvData
@@ -397,7 +397,7 @@ expandOffers chsets offs  =  do
 
 
 expandOffer :: [ Set.Set TxsDefs.ChanId ] -> Offer -> IOB.IOB ( CTOffer, [(VarId,IVar)], [(IVar,VExpr)] )
-expandOffer chsets (Offer chid choffs)  =  do
+expandOffer _chsets (Offer chid choffs)  =  do
      ctchoffs <- mapM (expandChanOffer chid) ( zip choffs [1..(length choffs)] )
      let ( ivars, quests, exclams ) = unzip3 ctchoffs
      return ( CToffer chid ivars, concat quests, concat exclams )
@@ -524,7 +524,7 @@ uniHVar (IVar ivname' ivuid' ivpos' ivstat' ivsrt')  =  do
      unid'   <- gets IOB.unid
      let newUnid = unid' + 1
      modify $ \env -> env { IOB.unid = newUnid }
-     return $ IVar (ivname'<>"$$$"<>showt ivuid') newUnid ivpos' ivstat' ivsrt'
+     return $ IVar (ivname'<>"$$$"<> (T.pack . show) ivuid') newUnid ivpos' ivstat' ivsrt'
 
 
 -- ----------------------------------------------------------------------------------------- --

--- a/sys/behavedefs/behavedefs.cabal
+++ b/sys/behavedefs/behavedefs.cabal
@@ -23,7 +23,6 @@ library
                       , containers
                       , MissingH
                       , text
-                      , text-show
 
                       , defs
 

--- a/sys/behavedefs/src/BTShow.hs
+++ b/sys/behavedefs/src/BTShow.hs
@@ -18,9 +18,7 @@ module BTShow
 where
 
 import qualified Data.Map          as Map
-import           Data.Monoid
 import qualified Data.String.Utils as Utils
-import           TextShow
 
 import           BTree
 import           TxsDefs

--- a/sys/behavedefs/src/BTree.hs
+++ b/sys/behavedefs/src/BTree.hs
@@ -39,13 +39,9 @@ where
 import           Data.Monoid
 import qualified Data.Set    as Set
 import qualified Data.Text   as T
-import           TextShow
 
 -- import from defs
 import           TxsDefs
-
--- import SolveDefs
--- import qualified SMTData as SMTData
 
 
 -- ----------------------------------------------------------------------------------------- --
@@ -71,7 +67,7 @@ data  IVar      =  IVar    { ivname :: Name       -- name of Channel
 
 instance Variable IVar where
     vname (IVar nm uid pos stat _srt) =
-      "$" <> nm <> "$" <> showt uid <> "$" <> showt stat <> "$" <> showt pos <> "$"
+      "$" <> nm <> "$" <> (T.pack . show) uid <> "$" <> (T.pack . show) stat <> "$" <> (T.pack . show) pos <> "$"
     vunid IVar{ ivuid = uid } = uid
     vsort IVar{ ivsrt = srt } = srt
     cstrVariable s i = IVar (T.pack s) i (-1) (-1)           -- PvdL for temporary variable

--- a/sys/cnect/src/EnDecode.hs
+++ b/sys/cnect/src/EnDecode.hs
@@ -30,8 +30,6 @@ where
 
 import qualified Data.Map  as Map
 import qualified Data.Set  as Set
-import           Data.Text (Text)
-import qualified Data.Text as T
 
 -- import from serverenv
 import qualified EnvServer as IOS

--- a/sys/cnect/src/SocketWorld.hs
+++ b/sys/cnect/src/SocketWorld.hs
@@ -36,7 +36,6 @@ import           System.IO
 -- import System.IO.Error
 import           Control.Concurrent
 import           Control.Monad.State
-import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           Network
 import           System.Timeout

--- a/sys/core/src/Mapper.hs
+++ b/sys/core/src/Mapper.hs
@@ -109,7 +109,7 @@ mapperMenu = do
   case (maybeMapperDef, mapSts) of
     ( Nothing, _  ) -> return []
     ( _      , [] ) -> return []
-    ( Just (TxsDefs.MapperDef chins chouts syncs _), mtree) ->
+    ( Just (TxsDefs.MapperDef _chins _chouts syncs _), mtree) ->
         return $ Behave.behMayMenu syncs mtree
 
 

--- a/sys/core/src/Purpose.hs
+++ b/sys/core/src/Purpose.hs
@@ -31,7 +31,6 @@ where
 import           Control.Monad.State
 
 import qualified Data.Set            as Set
-import           Data.Text           (Text)
 import qualified Data.Text           as T
 
 -- import from local

--- a/sys/core/src/Step.hs
+++ b/sys/core/src/Step.hs
@@ -133,7 +133,6 @@ stepModelMenu  =  do
        IOC.Stepping {IOC.modeldef = TxsDefs.ModelDef insyncs outsyncs splsyncs _bexp} -> do
          let allSyncs = insyncs ++ outsyncs ++ splsyncs
              curState = IOC.curstate envSt
-             nexState = IOC.maxstate envSt + 1
              modSts   = fromMaybe [] (Map.lookup curState (IOC.modstss envSt))
          return $ Behave.behMayMenu allSyncs modSts
        _ -> do

--- a/sys/core/src/TxsCore.hs
+++ b/sys/core/src/TxsCore.hs
@@ -114,7 +114,6 @@ import qualified Data.Map            as Map
 import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Set            as Set
-import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           System.Random
 

--- a/sys/coreenv/src/Config.hs
+++ b/sys/coreenv/src/Config.hs
@@ -18,9 +18,7 @@ module Config
   )
 where
 
-import           Data.Map       (Map)
 import qualified Data.Map       as Map
-import           Data.Maybe
 import           Data.Monoid
 import           System.Process
 

--- a/sys/defs/defs.cabal
+++ b/sys/defs/defs.cabal
@@ -69,7 +69,6 @@ library
                       , random
                       , MissingH
                       , text
-                      , text-show
                       , mtl
 
   default-language:     Haskell2010

--- a/sys/defs/src/Sigs.hs
+++ b/sys/defs/src/Sigs.hs
@@ -28,7 +28,6 @@ where
 import qualified Data.Map        as Map
 
 import           Control.DeepSeq
-import qualified Data.Text       as T
 import           GHC.Generics    (Generic)
 
 import           ChanId

--- a/sys/defs/src/TxsDDefs.hs
+++ b/sys/defs/src/TxsDDefs.hs
@@ -13,7 +13,6 @@ where
 
 import qualified Data.Set  as Set
 import           Data.Text (Text)
-import qualified Data.Text as T
 import           System.IO
 import           TxsDefs   (ChanId, Const, VExpr, VarId)
 import           TxsShow

--- a/sys/defs/src/TxsDefs.hs
+++ b/sys/defs/src/TxsDefs.hs
@@ -76,8 +76,6 @@ where
 import           Control.Arrow   ((***))
 import           Control.DeepSeq
 import qualified Data.Map        as Map
-import           Data.Text       (Text)
-import qualified Data.Text       as T
 import           GHC.Generics    (Generic)
 
 import           BehExprDefs     as X

--- a/sys/defs/src/TxsShow.hs
+++ b/sys/defs/src/TxsShow.hs
@@ -171,13 +171,13 @@ instance PShow BExpr
                  ++ " )"
          }
     pshow (Enable bexp1 chofs bexp2)
-      =  let last = pshow bexp2
+      =  let psBexp2 = pshow bexp2
             in
               "( " ++ pshow bexp1 ++ " )\n" ++ ">>>"
                  ++ case chofs of
-                    { []    -> last ++ "\n"
+                    { []    -> psBexp2 ++ "\n"
                     ; _     -> " ACCEPT\n" ++ Utils.join "\n" (map pshow chofs)
-                               ++ "\nIN\n" ++ last ++ "\nNI\n"
+                               ++ "\nIN\n" ++ psBexp2 ++ "\nNI\n"
                     }
     pshow (Disable bexp1 bexp2)
       =  "( " ++ pshow bexp1 ++ " )\n"

--- a/sys/defs/src/VarId.hs
+++ b/sys/defs/src/VarId.hs
@@ -19,7 +19,6 @@ import           Data.Monoid
 import qualified Data.Text       as T
 import           Name
 import           SortId
-import           TextShow
 import           Variable
 
 data VarId          = VarId     { name    :: Name             --smallid
@@ -29,7 +28,7 @@ data VarId          = VarId     { name    :: Name             --smallid
      deriving (Eq,Ord,Read,Show, Generic, NFData)
 
 instance Variable VarId where
-  vname v            = VarId.name v <> "$$" <> showt (VarId.unid v)
+  vname v            = VarId.name v <> "$$" <> (T.pack . show) (VarId.unid v)
   vunid              = VarId.unid
   vsort              = VarId.varsort
   cstrVariable       = VarId . T.pack

--- a/sys/defs/src/XmlFormat.hs
+++ b/sys/defs/src/XmlFormat.hs
@@ -15,9 +15,7 @@ import           CstrId
 import           Data.ByteString          (pack)
 import           Data.ByteString.Internal (c2w)
 import           Data.Char                (chr, ord)
-import           Data.Foldable
 import qualified Data.Map                 as Map
-import           Data.Monoid
 import           Data.String
 import           Data.Text                (Text)
 import qualified Data.Text                as T
@@ -25,7 +23,6 @@ import           FuncId
 import           SortId
 import           StdTDefs
 import           Text.XML.Expat.Tree
-import           TextShow
 import           TxsDefs
 
 
@@ -41,7 +38,7 @@ xmlTreeToText tree = T.concat $ reverse $ execState (xmlTreeToList tree) []
     xmlTreeToList (XLeaf text) = modify (text:)
     xmlTreeToList (XNode text ts) = do
       modify (T.concat ["<", text, ">" ]:)
-      traverse xmlTreeToList ts
+      _ <- traverse xmlTreeToList ts
       modify (T.concat ["</", text, ">" ]:)
 
 instance IsString XMLTree where
@@ -119,7 +116,7 @@ pairNameConstToXml _ (n, Cbool True) =
 pairNameConstToXml _ (n, Cbool False) =
   n ~> ["false"]
 pairNameConstToXml _ (n, Cint i) =
-  n ~> [XLeaf (showt i)]
+  n ~> [XLeaf (T.pack (show i))]
 pairNameConstToXml _ (n, Cstring s) =
   n ~> [XLeaf (encodeString s)]
 pairNameConstToXml tdefs (n, Cstr cid wals) =

--- a/sys/server/src/CmdLineParser.hs
+++ b/sys/server/src/CmdLineParser.hs
@@ -15,7 +15,6 @@ import           Data.Semigroup      ((<>))
 import           Options.Applicative
 
 -- imports from `core`
-import           Config
 import           Network
 
 -- | Configuration options read by the command line.

--- a/sys/server/src/ToProcdef.hs
+++ b/sys/server/src/ToProcdef.hs
@@ -20,10 +20,8 @@ module ToProcdef
 
 where
 
-import           Data.Foldable
 import           Data.Monoid
 import qualified Data.Set          as Set
-import qualified Data.String.Utils as Utils
 import           Data.Text         (Text)
 import qualified Data.Text         as T
 

--- a/sys/server/src/TxsServer.hs
+++ b/sys/server/src/TxsServer.hs
@@ -33,7 +33,6 @@ import qualified Data.Char           as Char
 import qualified Data.List           as List
 import qualified Data.Map            as Map
 import qualified Data.Set            as Set
-import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           Network
 import           System.IO
@@ -49,7 +48,6 @@ import qualified IfServer            as IFS
 
 -- import from core
 import qualified BuildInfo
-import qualified Config              as CoreConfig
 import qualified TxsCore
 import qualified VersionInfo
 

--- a/sys/server/src/TxsServerConfig.hs
+++ b/sys/server/src/TxsServerConfig.hs
@@ -18,15 +18,11 @@ import           CmdLineParser
 import           Config
 import           Control.Monad.Extra
 import           Data.Aeson.Types
-import           Data.Bifunctor
-import           Data.Foldable
-import           Data.Map            (Map)
 import qualified Data.Map            as Map
 import           Data.Maybe
 import           Data.Monoid
 import           Data.Yaml
 import           GHC.Generics
-import           Network
 import           System.Directory
 import           System.FilePath
 

--- a/sys/solve/solve.cabal
+++ b/sys/solve/solve.cabal
@@ -44,7 +44,6 @@ library
                       , time
                       , MissingH
                       , text
-                      , text-show
 
                       , defs
                       , value
@@ -110,7 +109,6 @@ test-suite SmtSolver-WhiteBox
                       , solvedefs
                       , value
                       , text
-                      , text-show                      
 
                       , coreenv
 
@@ -140,7 +138,6 @@ test-suite SmtSolver-BlackBox
                       , solvedefs
                       , value
                       , text
-                      , text-show                      
 
                       , coreenv
 

--- a/sys/solve/src/RandIncrementChoice.hs
+++ b/sys/solve/src/RandIncrementChoice.hs
@@ -26,7 +26,6 @@ import           System.Random.Shuffle
 
 import qualified Data.Char             as Char
 import qualified Data.Map              as Map
-import qualified Data.String.Utils     as Utils
 
 import           Data.Monoid
 import           Data.Text             (Text)

--- a/sys/solve/src/RandTrueBins.hs
+++ b/sys/solve/src/RandTrueBins.hs
@@ -29,13 +29,11 @@ import qualified Data.Char             as Char
 import qualified Data.Map              as Map
 import           Data.Monoid
 import qualified Data.Set              as Set
-import qualified Data.String.Utils     as Utils
 import           Data.Text             (Text)
 import qualified Data.Text             as T
 import           System.IO
 import           System.Random
 import           System.Random.Shuffle
-import           TextShow
 
 import           SMT
 import           SMTData
@@ -213,7 +211,7 @@ trueStringLength n v = do
 trueStringRegex :: (Variable v) => Int -> ValExpr v -> SMT Text
 trueStringRegex n v = do
     regexes <- trueCharsRegexes n
-    sregexes <- shuffleM (regexes <> [range <> "{"<> showt (n+1) <> ",}"])               -- Performance gain in problem solver? Use string length for length 0 and greater than n
+    sregexes <- shuffleM (regexes <> [range <> "{"<> (T.pack . show) (n+1) <> ",}"])               -- Performance gain in problem solver? Use string length for length 0 and greater than n
     let shuffledOrList = map (\regex -> cstrFunc funcId_strinre [v, cstrConst (Cregex regex)]) sregexes
     stringList <- mapM valExprToString shuffledOrList
     return $ "(or " <> T.intercalate " " stringList <> ") "

--- a/sys/solve/src/SMT2TXS.hs
+++ b/sys/solve/src/SMT2TXS.hs
@@ -26,10 +26,8 @@ where
 
 import qualified Data.Map          as Map
 import           Data.Monoid
-import           Data.String.Utils
 import           Data.Text         (Text)
 import qualified Data.Text         as T
-import           TextShow
 
 import           CstrId
 import           SortId

--- a/sys/solve/src/SMTInternal.hs
+++ b/sys/solve/src/SMTInternal.hs
@@ -23,8 +23,7 @@ import           Control.Monad.State (gets, lift, modify)
 import qualified Data.List           as List
 import qualified Data.Map            as Map
 import qualified Data.Set            as Set
-import           Data.String.Utils   (endswith, join, replace, startswith,
-                                      strip)
+import           Data.String.Utils   (endswith, replace, startswith, strip)
 import           Data.Time
 import           System.IO
 import           System.Process

--- a/sys/solve/src/TXS2SMT.hs
+++ b/sys/solve/src/TXS2SMT.hs
@@ -34,15 +34,12 @@ module TXS2SMT
 
 where
 
-import           Data.Foldable
 import qualified Data.Map          as Map
 import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Set          as Set
-import           Data.String.Utils
 import           Data.Text         (Text)
 import qualified Data.Text         as T
-import           TextShow
 
 import           CstrId
 import           FuncId
@@ -111,7 +108,7 @@ initialMapInstanceTxsToSmtlib  =  [
 -- initialMapInstanceTxsToSmtlib
 
 toFieldName :: CstrId -> Int -> Text
-toFieldName cstrid field  =  T.concat [toCstrName cstrid, "$", showt field]
+toFieldName cstrid field  =  T.concat [toCstrName cstrid, "$", (T.pack . show) field]
 
 toIsCstrName :: CstrId -> Text
 toIsCstrName cstrid  =  "is-" <> toCstrName cstrid
@@ -123,7 +120,7 @@ toSortName :: SortId -> Text
 toSortName = SortId.name
 
 toFuncName :: FuncId -> Text
-toFuncName funcId  =  T.concat ["f", showt (FuncId.unid funcId), "$", FuncId.name funcId]
+toFuncName funcId  =  T.concat ["f", (T.pack . show) (FuncId.unid funcId), "$", FuncId.name funcId]
 
 insertMap :: (Ident, TxsDef) -> Map.Map Ident Text -> Map.Map Ident Text
 insertMap (id'@(IdSort sid), DefSort SortDef) mp
@@ -236,8 +233,8 @@ constToSMT _ (Cbool b) = if b
                             then "true"
                             else "false"
 constToSMT _ (Cint n) = if n < 0
-                            then "(- " <> showt (abs n) <> ")"
-                            else showt n
+                            then "(- " <> (T.pack . show) (abs n) <> ")"
+                            else (T.pack . show) n
 constToSMT _ (Cstring s)  =  "\"" <> encodeStringLiteral s <> "\""
 constToSMT _ (Cregex r)  =  parseRegex r
 constToSMT mapI (Cstr cd [])   =        justLookup mapI (IdCstr cd)

--- a/sys/testsel/src/NComp.hs
+++ b/sys/testsel/src/NComp.hs
@@ -26,7 +26,7 @@ where
 import qualified Data.List   as List
 import           Data.Monoid
 import qualified Data.Set    as Set
-import           TextShow
+import qualified Data.Text           as T
 
 import qualified EnvCore     as IOC
 
@@ -46,7 +46,7 @@ nComplete insyncs outsyncs
                     , Set.singleton StdTDefs.chanId_Hit
                     , Set.singleton StdTDefs.chanId_Miss
                     ]
-         gids     = [ TxsDefs.GoalId ("Goal_" <> nm <> nm' <> showt n ) (uid*uid'+n) | n <- [1..] ]
+         gids     = [ TxsDefs.GoalId ("Goal_" <> nm <> nm' <> (T.pack . show) n ) (uid*uid'+n) | n <- [1..] ]
          goals    = [ (gid,bexp) | (gid,bexp) <- zip gids (allPaths ini transs) ]
       in return $ Just $ TxsDefs.PurpDef insyncs outsyncs splsyncs goals
 

--- a/sys/testsel/testsel.cabal
+++ b/sys/testsel/testsel.cabal
@@ -26,7 +26,6 @@ library
                       , containers
                       , mtl
                       , text
-                      , text-show
 
                       , coreenv
                       , defs

--- a/sys/value/src/Eval.hs
+++ b/sys/value/src/Eval.hs
@@ -34,9 +34,7 @@ import           Data.Maybe
 import           Data.Monoid
 import           Data.Text           (Text)
 import qualified Data.Text           as T
-import           Data.Text.Read
 import           Text.Regex.TDFA
-import           TextShow
 
 import qualified Data.List           as List
 import qualified Data.Map            as Map
@@ -241,7 +239,7 @@ evalSSB :: Variable v => FuncId -> [ValExpr v] -> IOB.IOB Const
 evalSSB (FuncId nm _ _ _) vexps =
      case ( nm, vexps ) of
        ( "toString",    [v1]    ) -> do b1 <- txs2bool v1
-                                        str2txs $ showt b1
+                                        str2txs $ (T.pack . show) b1
        ( "fromString",  [v1]    ) -> do s1 <- txs2str v1
                                         bool2txs $ readBool s1
        ( "toXml",       [v1]    ) -> do wal <- eval v1
@@ -261,7 +259,7 @@ evalSSI :: Variable v => FuncId -> [ValExpr v] -> IOB.IOB Const
 evalSSI (FuncId nm _ _ _) vexps =
      case ( nm, vexps ) of
        ( "toString",    [v1]    ) -> do i1 <- txs2int v1
-                                        str2txs $ showt i1
+                                        str2txs $ (T.pack . show) i1
        ( "fromString",  [v1]    ) -> do s1 <- txs2str v1
                                         int2txs $ read (T.unpack s1)
        ( "toXml",       [v1]    ) -> do wal <- eval v1

--- a/sys/value/value.cabal
+++ b/sys/value/value.cabal
@@ -32,7 +32,6 @@ library
                       , regex-tdfa
                       , MissingH
                       , text
-                      , text-show
                       
                       , behaveenv
                       , defs
@@ -61,8 +60,7 @@ test-suite Value-WhiteBox
                       , base
                       , HUnit
                       , text
-                      , text-show                      
-                  
+                 
   ghc-options:         -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N
 
   default-language:     Haskell2010


### PR DESCRIPTION
On windows, TorXakis can not use integer-gmp due to license issues.
text-show uses integer-gmp, so text-show can not be used.

Also removed a number of warnings (found with -Wall / --pedantic)