### PR TITLE
Typo in config file

### DIFF
--- a/.torxakis.yaml
+++ b/.torxakis.yaml
@@ -1,4 +1,4 @@
-selected-solver: "z3str3"
+selected-solver: "z3"
 available-solvers:
 - solver-id: "z3"
   executable-name: "z3"

--- a/.torxakis.yaml
+++ b/.torxakis.yaml
@@ -1,4 +1,4 @@
-selected-solver: "z3"
+selected-solver: "z3str3"
 available-solvers:
 - solver-id: "z3"
   executable-name: "z3"
@@ -10,7 +10,7 @@ available-solvers:
   flags:
   - "-smt2"
   - "-in"
-  - "-smt.string_solver=z3str3"
+  - "smt.string_solver=z3str3"
 - solver-id: "cvc4"
   executable-name: "cvc4"
   flags:


### PR DESCRIPTION
Current situation:

c:\>z3 -smt.string_solver=z3str3
Error: invalid command line option: -smt.string_solver=z3str3
For usage information: z3 -h

correct situation

C:\>z3 smt.string_solver=z3str3
Error: input file was not specified.
For usage information: z3 -h