### PR TITLE
ITE made smarter

### DIFF
--- a/sys/defs/src/ValExprImpls.hs
+++ b/sys/defs/src/ValExprImpls.hs
@@ -148,9 +148,11 @@ cstrVar v = ValExpr (Vvar v)
 -- | Apply operator ITE (IF THEN ELSE) on the provided value expressions.
 -- Preconditions are /not/ checked.
 cstrITE :: ValExpr v -> ValExpr v -> ValExpr v -> ValExpr v
+cstrITE (view -> Vconst (Cbool True))  tb _ = tb
+cstrITE (view -> Vconst (Cbool False)) _ fb = fb
 -- if (not b) then tb else fb == if b then fb else tb
-cstrITE (view -> Vnot n) tb fb = ValExpr (Vite n fb tb)
-cstrITE cs tb fb               = ValExpr (Vite cs tb fb)
+cstrITE (view -> Vnot n) tb fb              = ValExpr (Vite n fb tb)
+cstrITE cs tb fb                            = ValExpr (Vite cs tb fb)
 
 -- | Apply operator Equal on the provided value expressions.
 -- Preconditions are /not/ checked.

--- a/sys/front/src/TxsHappy.y
+++ b/sys/front/src/TxsHappy.y
@@ -492,12 +492,12 @@ TypeDef         -- :: { [ (Ident,TxsDef) ] }
                 ;  $$.synSigs      = let dsort = SortId $1 $$.inhNodeUid in
                                         Sigs.uniqueCombine  Sigs.empty { Sigs.sort = Map.singleton $1 dsort
                                                                        , Sigs.func = FuncTable (Map.fromList [ (eqName, Map.singleton (Signature [dsort,dsort] sortId_Bool) equalHandler)
-                                                                                                        , (neqName, Map.singleton (Signature [dsort,dsort] sortId_Bool) notEqualHandler)
-                                                                                                        , (toStringName, Map.singleton (Signature [dsort] sortId_String) (cstrPredef AST (FuncId toStringName ($$.inhNodeUid+3) [dsort] sortId_String) ) )
-                                                                                                        , (fromStringName, Map.singleton (Signature [sortId_String] dsort) (cstrPredef ASF (FuncId fromStringName ($$.inhNodeUid+4) [sortId_String] dsort) ) )
-                                                                                                        , (toXmlName, Map.singleton (Signature [dsort] sortId_String) (cstrPredef AXT (FuncId toStringName ($$.inhNodeUid+5) [dsort] sortId_String) ) )
-                                                                                                        , (fromXmlName, Map.singleton (Signature [sortId_String] dsort) (cstrPredef AXF (FuncId fromStringName ($$.inhNodeUid+6) [sortId_String] dsort) ) )
-                                                                                                        ] ) 
+                                                                                                             , (neqName, Map.singleton (Signature [dsort,dsort] sortId_Bool) notEqualHandler)
+                                                                                                             , (toStringName, Map.singleton (Signature [dsort] sortId_String) (cstrPredef AST (FuncId toStringName ($$.inhNodeUid+3) [dsort] sortId_String) ) )
+                                                                                                             , (fromStringName, Map.singleton (Signature [sortId_String] dsort) (cstrPredef ASF (FuncId fromStringName ($$.inhNodeUid+4) [sortId_String] dsort) ) )
+                                                                                                             , (toXmlName, Map.singleton (Signature [dsort] sortId_String) (cstrPredef AXT (FuncId toStringName ($$.inhNodeUid+5) [dsort] sortId_String) ) )
+                                                                                                             , (fromXmlName, Map.singleton (Signature [sortId_String] dsort) (cstrPredef AXF (FuncId fromStringName ($$.inhNodeUid+6) [sortId_String] dsort) ) )
+                                                                                                             ] ) 
                                                                        }
                                                             $3.synSigs  
                 ;  $3.inhSigs      = $$.inhSigs
@@ -574,10 +574,8 @@ Constructor     -- :: { [ (Ident,TxsDef) ] }
                                    ]
                             }
                             in [ ( IdCstr cid, DefCstr (CstrDef cfid (map (\(IdFunc f,_) -> f) fs) ) ) 
-                               , ( IdFunc cfid, DefFunc (FuncDef [x] (cstrIsCstr cid (cstrVar x) ) ) )
                                ]
-                               ++
-                               fs
+                               
                 ;  where let dbls = doubles ([$1, "is" <> $1] ++ map fst $2)
                           in if null dbls then () else
                              error $ "\nTXS0803: " ++

--- a/sys/solve/src/RandIncrementChoice.hs
+++ b/sys/solve/src/RandIncrementChoice.hs
@@ -261,8 +261,8 @@ randomSolve p ((v,d):xs) i =
         choicesFunc v' partA partB Cstr{cstrId = cId} =
             do
                 let cond = Map.member cId (Map.fromList partA)
-                lA <- mapM (\(cid,CstrDef{}) -> valExprToString $ cstrIsCstr cid (cstrVar v')) partA
-                lB <- mapM (\(cid,CstrDef{}) -> valExprToString $ cstrIsCstr cid (cstrVar v')) partB
+                lA <- mapM (\(tempCid,CstrDef{}) -> valExprToString $ cstrIsCstr tempCid (cstrVar v')) partA
+                lB <- mapM (\(tempCid,CstrDef{}) -> valExprToString $ cstrIsCstr tempCid (cstrVar v')) partB
                 return [ (cond, case lA of
                                     [a] -> a
                                     _   -> "(or " <> T.intercalate " " lA <> ") ")

--- a/sys/solve/src/RandTrueBins.hs
+++ b/sys/solve/src/RandTrueBins.hs
@@ -253,7 +253,7 @@ randomValue p sid expr n | n > 0 =
                     return (r:rr)
 
                 processConstructor :: (Variable v) => (CstrId,CstrDef) -> ValExpr v -> SMT Text
-                processConstructor (cid,CstrDef _isX []) expr' = valExprToString $ cstrIsCstr cid expr'
+                processConstructor (cid, CstrDef _isX []) expr' = valExprToString $ cstrIsCstr cid expr'
                 processConstructor (cid, CstrDef _isX _accessors) expr' = do
                     cstr <- valExprToString $ cstrIsCstr cid expr'
                     args' <- processArguments cid (zip (cstrargs cid) [0..]) expr'


### PR DESCRIPTION
forgot to copy
IF true the tb else fb -> tb
IF false the tb else fb -> fb

consequently, substitution took place under invalid constraints
(e.g. head was taken on Nil list)

fixes #324 


additionally: improved layout + made temp variables more explicit