### PR TITLE
Reorganized AppVeyor cache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,7 +71,7 @@ cache:
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-8.0.2.installed'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.0.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.0.2.installed'
-# - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512'
+- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512.installed'
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,6 @@ install:
     } else {
         Write-Host "stack.exe found.";
     }
-- stack --version
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\cvc4.exe")) {
         # obtain the cvc4 executable
@@ -52,10 +51,10 @@ before_build:
 - ps: $env:CACHE_DIR_REL = $CACHE_DIR_REL
 
 build_script:
-- stack install --pedantic --install-ghc --test --fast --no-terminal --work-dir %CACHE_DIR_REL%\.stack-work --stack-root %STACK_ROOT%
+- stack install --pedantic --install-ghc --test --fast --no-terminal --stack-root %STACK_ROOT%
 
 # after_build:
-# - 
+# -
 
 # before_test:
 # - 
@@ -63,21 +62,22 @@ build_script:
 clone_folder: c:\TorXakis
 environment:
   global:
-    STACK_ROOT: c:\TorXakis\.cache\.stack
+    STACK_ROOT: c:\TorXakis\.stack
 
 cache:
+- .stack -> .stack.yaml
 - .cache
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-8.0.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-8.0.2.installed'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.0.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.0.2.installed'
-- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512'
+# - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512.installed'
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
 - ps: pushd test/sqatt
-- stack test --install-ghc --test-arguments="--skip=#model" --no-terminal --work-dir %CACHE_DIR_REL%\test\.stack_work --stack-root %STACK_ROOT%
+- stack test --install-ghc --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT%
 - ps: popd
 
 # after_test:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![TorXakis logo](https://user-images.githubusercontent.com/661967/29917789-506f21fa-8e43-11e7-9804-596decacebe4.png "TorXakis")
 
-[![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/shields_badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)[![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis)
+[![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)
+[![Build status](https://ci.appveyor.com/api/projects/status/sv3e96co0019taf9?svg=true)](https://ci.appveyor.com/project/keremispirli/torxakis)
+[![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis)
+
 # TorXakis
 
 TorXakis is a tool for Model Based Testing.


### PR DESCRIPTION
Caches .stack separately from .cache
Doesn't cache .stack_work
Caches msys2.installed file but not the actual folder
 (looks like it's not necessary for build)
Added AppVeyor badge to README.md, replaced SemaphoreCI badge
Removed stack --version command

Resolves #329 