### PR TITLE
Feat/torxakis snap package

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((haskell-mode
+  (intero-targets . "stack_linux.yaml")))

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ docs/wiki/_build
 
 /*Proc.txs
 /*Purpose.txs
+
+# Snapcraft artifacts
+parts
+prime
+stage
+snap/.snapcraft
+*.snap

--- a/.torxakis.yaml
+++ b/.torxakis.yaml
@@ -1,7 +1,6 @@
 # TorXakis - Model Based Testing
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
-
 selected-solver: "z3"
 available-solvers:
 - solver-id: "z3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![TorXakis logo](https://git.io/vFvfj "TorXakis")
 
-[![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/shields_badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)[![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis)
+[![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/shields_badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)
+[![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
 # TorXakis
 
 TorXakis is a tool for Model Based Testing.
@@ -11,17 +13,108 @@ It is licensed under the [BSD3 license](LICENSE).
 User documentation at [our wiki](https://github.com/TorXakis/TorXakis/wiki).
 
 ## For Developers
-TorXakis is written in [Haskell](https://www.haskell.org).
 
-TorXakis uses [stack](https://www.haskellstack.org) to build.
+TorXakis is written in [Haskell](https://www.haskell.org) and
+uses [`stack`][9] as build tool. In addition
+TorXakis needs an [SMT][1] solver, such as [cvc4][2] or [Z3][3]. The SMT Solver
+needs to support [SMTLIB][4] version 2.5, [Algebraic Data Types][5] (as
+proposed for version 2.6), and [Strings][6]. The SMT Solvers are assumed to be
+located on the [PATH][7]. For development acceptance tests [javac][8] is needed.
 
-TorXakis needs a [SMT](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories) Solver, such as 
-[cvc4](http://cvc4.cs.stanford.edu/web/) and [Z3](https://github.com/Z3Prover/z3).
-The SMT Solver needs to support [SMTLIB](http://smtlib.cs.uiowa.edu/) version 2.5,
-[Algebraic Data Types](https://en.wikipedia.org/wiki/Algebraic_data_type) (as proposed for version 2.6), 
-and [Strings](http://cvc4.cs.stanford.edu/wiki/Strings).
-The SMT Solvers are assumed to be located on the [PATH](https://en.wikipedia.org/wiki/PATH_(variable)).
+The Haddock documentation is also
+available [here](https://torxakis.github.io/TorXakis/doc/index.html).
 
-TorXakis uses [javac](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [GNU Make](https://www.gnu.org/software/make/) for development acceptance tests.
+### Building
 
-[Haddock Docs](https://torxakis.github.io/TorXakis/doc/index.html)
+Make sure that [`stack`][10] is installed, then clone this repository. To build
+and install `TorXakis` locally, if you are on a Windows system run:
+
+```sh
+stack setup
+stack install
+```
+
+For Unix systems a different stack configuration is used:
+
+```sh
+stack setup --stack-yaml stack_linux.yaml
+stack install --stack-yaml stack_linux.yaml
+```
+
+The build might take an hour depending on the host system. There is
+an [issue][11] filed to improve this. Alternatively the `--fast` flag can be
+used:
+
+```sh
+stack install --fast
+```
+
+or on Unix systems:
+
+```sh
+stack install --fast --stack-yaml stack_linux.yaml
+```
+
+This disables all optimizations and takes the compile time down to
+around 5 minutes, however bear in mind that `TorXakis` will be slightly slower
+(for instance we experience a 10 seconds overhead when testing a model that
+took `30` about seconds with the optimized version).
+
+The reason for having two configuration files is that on Windows systems the
+libraries are linked statically, and thus we cannot use the `integer-gmp`
+library, since `TorXakis` is licensed under the [BSD3 license](LICENSE).
+
+In the instructions that follow we will omit the `--stack-yaml
+stack-linux.yaml` flag, but bear in mind that if you're in an Unix system you
+need to add it (or set the `STACK_YAML` environment variable to
+"stack-linux.yaml")
+
+### Testing
+
+When submitting a pull request, our continuous integration process will run a
+series of tests. There are two levels of tests that we use in `TorXakis`:
+unit-tests and integration tests. Unit-tests can be run when building using
+`stack` by passing this `--test` flag:
+
+```sh
+stack install --test
+```
+
+To run the integration tests go to the `test/sqatt` folder, and run:
+
+```sh
+stack test
+```
+
+See the [README](test/sqatt/README.md) in the `sqatt` folder for more
+information.
+
+### Repository structure
+
+There are several folders in this repository, which serve different purposes:
+
+- [`bin`](bin/): utility scripts to start `TorXakis` UI and server.
+- [`ci`](ci/): scripts used in our continuous integration process.
+- [`docs`](docs/): documentation files for `TorXakis`.
+- [`examps`](examps/): example models and systems-under-test (SUT's) to play
+  around with.
+- [`snap`](snap/): files needed to create Linux [snaps][12].
+- [`sys`](sys/): packages that make up `TorXakis` this is where the source code
+  resides.
+- [`test`](test/): utilities for quality assurance tests (integration-tests,
+  license-checking, etc).
+
+See the README files in each folders to get a more detailed explanation.
+
+[1]: https://en.wikipedia.org/wiki/Satisfiability_modulo_theories
+[2]: http://cvc4.cs.stanford.edu/web/
+[3]: https://github.com/Z3Prover/z3
+[4]: http://smtlib.cs.uiowa.edu/
+[5]: https://en.wikipedia.org/wiki/Algebraic_data_type
+[6]: http://cvc4.cs.stanford.edu/wiki/Strings
+[7]: https://en.wikipedia.org/wiki/PATH_(variable)
+[8]: https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
+[9]: https://www.haskellstack.org
+[10]: https://docs.haskellstack.org/en/stable/install_and_upgrade/
+[11]: https://github.com/TorXakis/TorXakis/issues/40
+[12]: https://www.ubuntu.com/desktop/snappy

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)
 [![Build status](https://ci.appveyor.com/api/projects/status/sv3e96co0019taf9?svg=true)](https://ci.appveyor.com/project/keremispirli/torxakis)
 [![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis)
-    [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 # TorXakis
 
@@ -25,10 +25,8 @@ For Linux systems we provide a [`snap`][`12`] package. To install `TorXakis`
 run:
 
 ```sh
-sudo snap install torxakis
+sudo snap install torxakis --edge
 ```
-
-**TODO**: verify these instructions.
 
 When running `TorXakis` as a snap, the configuration file for `TorXakis` should
 go in the `~/snap/torxakis/current` directory. This is because snaps run in an

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ It is licensed under the [BSD3 license](LICENSE).
 ## For Users
 User documentation at [our wiki](https://github.com/TorXakis/TorXakis/wiki).
 
+## Installation
+
+### Windows
+For Windows systems an installer is provided in the [releases][13] section.
+
+### Linux
+
+For Linux systems we provide a [`snap`][`12`] package. To install `TorXakis`
+run:
+
+```sh
+sudo snap install torxakis
+```
+
+**TODO**: verify these instructions.
+
+When running `TorXakis` as a snap, the configuration file for `TorXakis` should
+go in the `~/snap/torxakis/current` directory. This is because snaps run in an
+isolated environment, and they are not able to see any hidden files in the
+users home directory.
+
 ## For Developers
 
 TorXakis is written in [Haskell](https://www.haskell.org) and
@@ -118,3 +139,4 @@ See the README files in each folders to get a more detailed explanation.
 [10]: https://docs.haskellstack.org/en/stable/install_and_upgrade/
 [11]: https://github.com/TorXakis/TorXakis/issues/40
 [12]: https://www.ubuntu.com/desktop/snappy
+[13]: https://github.com/TorXakis/TorXakis/releases

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ stack install --fast --stack-yaml stack_linux.yaml
 This disables all optimizations and takes the compile time down to
 around 5 minutes, however bear in mind that `TorXakis` will be slightly slower
 (for instance we experience a 10 seconds overhead when testing a model that
-took `30` about seconds with the optimized version).
+took about `30` seconds with the optimized version).
 
 The reason for having two configuration files is that on Windows systems the
 libraries are linked statically, and thus we cannot use the `integer-gmp`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![TorXakis logo](https://user-images.githubusercontent.com/661967/29917789-506f21fa-8e43-11e7-9804-596decacebe4.png "TorXakis")
+![TorXakis logo](https://git.io/vFvfj "TorXakis")
 
 [![Build Status](https://semaphoreci.com/api/v1/capitanbatata/torxakis/branches/develop/shields_badge.svg)](https://semaphoreci.com/capitanbatata/torxakis)[![Code Climate](https://codeclimate.com/github/TorXakis/TorXakis/badges/gpa.svg)](https://codeclimate.com/github/TorXakis/TorXakis)
 # TorXakis

--- a/snap/README.md
+++ b/snap/README.md
@@ -22,3 +22,11 @@ and then create the snap by running:
 ```sh
 snapcraft
 ```
+
+If you rebuild `TorXakis` remember to clean `torxakis-bin`:
+
+```sh
+snapcraft clean torxakis-bin 
+```
+
+The command above will make sure that the new executable packaged.

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,24 @@
+# Snap package configuration for TorXakis
+
+`TorXakis` provides a [`snap`](https://www.ubuntu.com/desktop/snappy) package,
+which allows users of Linux systems to readily install `TorXakis`. This folder
+contains the files necessary to create such package.
+
+To create this snap make sure `snapcraft` is installed:
+
+```sh
+sudo snap install --beta --classic snapcraft 
+```
+
+Then at the root level of the `TorXakis` repository, make sure you build
+`TorXakis` to create the binaries that will be packaged into the snap:
+
+```sh
+stack build --test --stack-yaml stack_linux.yaml
+```
+
+and then create the snap by running:
+
+```sh
+snapcraft
+```

--- a/snap/data/.torxakis.yaml
+++ b/snap/data/.torxakis.yaml
@@ -1,0 +1,25 @@
+# TorXakis - Model Based Testing
+# Copyright (c) 2015-2017 TNO and Radboud University
+# See LICENSE at root directory of this repository.
+selected-solver: "z3"
+available-solvers:
+- solver-id: "z3"
+  executable-name: "z3"
+  flags:
+  - "-smt2"
+  - "-in"
+- solver-id: "z3str3"
+  executable-name: "z3"
+  flags:
+  - "-smt2"
+  - "-in"
+  - "smt.string_solver=z3str3"
+- solver-id: "cvc4"
+  executable-name: "cvc4"
+  flags:
+  - "--lang=smt"
+  - "--incremental"
+  - "--strings-exp"
+  - "--fmf-fun-rlv"
+  - "--uf-ss-fair"
+  - "--no-strings-std-ascii"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Installation script to run upon snap installation.
+
+# Empty for now...

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,18 @@ parts:
     source: .stack-work/install/x86_64-linux-nopie/lts-9.7/8.0.2/bin/
     stage-packages: []
 
+  torxakis-bootstrap-data:
+    # Bootstrap data for TorXakis, for instance initial configuration.
+    #
+    # This makes the `snap/data` folder available, and data can be copied upon
+    # starting `TorXakis`, for instance, as follows:
+    #
+    # cp $SNAP/snap/data/* $SNAP_USER_DATA/
+    #
+    # See: https://forum.snapcraft.io/t/use-of-home-and-network-plugs/2587/19
+    plugin: dump
+    source: snap/data
+    
   cvc4-bin:
     plugin: dump
     source: https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.5/cvc4-1.5-x86_64-linux-opt.tar.gz
@@ -22,7 +34,7 @@ parts:
   z3-bin:
     plugin: dump
     source: https://github.com/TorXakis/Dependencies/releases/download/z3-4.5.1/z3-4.5.1.x64-ubuntu-14.04.tar.gz
-
+    
 apps:
   txsui:
     command: txsui

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,3 +56,11 @@ apps:
       - network
       - home
       - network-bind
+
+  cvc4:
+    command: cvc4-1.5-x86_64-linux-opt
+    plugs:
+      - network
+      - home
+      - network-bind
+      

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,6 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict  # use 'strict' once you have the right plugs and slots
 
-
 parts:  
   torxakis-bin:
     # See 'snapcraft plugins'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,7 @@
+# TorXakis - Model Based Testing
+# Copyright (c) 2015-2017 TNO and Radboud University
+# See LICENSE at root directory of this repository.
+
 name: torxakis # you probably want to 'snapcraft register <name>'
 version: 'nightly' # just for humans, typically '1.2+git' or '1.3.2'
 summary: A tool for testing systems using a model-based approach. # 79 char long summary

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,47 @@
+name: torxakis # you probably want to 'snapcraft register <name>'
+version: 'nightly' # just for humans, typically '1.2+git' or '1.3.2'
+summary: A tool for testing systems using a model-based approach. # 79 char long summary
+description: |
+  TorXakis allows to test systems by writing models in a process algebraic
+  fashion. 
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict  # use 'strict' once you have the right plugs and slots
+
+
+parts:  
+  torxakis-bin:
+    # See 'snapcraft plugins'
+    plugin: dump
+    source: .stack-work/install/x86_64-linux-nopie/lts-9.7/8.0.2/bin/
+    stage-packages: []
+
+  cvc4-bin:
+    plugin: dump
+    source: https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.5/cvc4-1.5-x86_64-linux-opt.tar.gz
+
+  z3-bin:
+    plugin: dump
+    source: https://github.com/TorXakis/Dependencies/releases/download/z3-4.5.1/z3-4.5.1.x64-ubuntu-14.04.tar.gz
+
+apps:
+  txsui:
+    command: txsui
+    plugs:  # TODO: how to get this working in `strict` mode?
+      - network
+      - home
+      - network-bind
+
+  txsserver:
+    command: txsserver
+    plugs: 
+      - network
+      - home
+      - network-bind
+
+  z3:
+    command: bin/z3
+    plugs:
+      - network
+      - home
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
 apps:
   txsui:
     command: txsui
-    plugs:  # TODO: how to get this working in `strict` mode?
+    plugs:
       - network
       - home
       - network-bind

--- a/sys/server/src/TxsServerConfig.hs
+++ b/sys/server/src/TxsServerConfig.hs
@@ -25,6 +25,7 @@ import           Data.Yaml
 import           GHC.Generics
 import           System.Directory
 import           System.FilePath
+import           System.IO
 
 -- | Uninterpreted configuration options.
 data UnintConfig = UnintConfig
@@ -141,9 +142,11 @@ loadConfigFromFile :: IO (Maybe FileConfig)
 loadConfigFromFile = do
   mPath <- findConfigFile
   case mPath of
-    Nothing ->
+    Nothing -> do
+      hPutStrLn stderr "No configuration file found."  -- TODO: add a `DEBUG` flag to torxakis.
       return Nothing
     Just path -> do
+      hPutStrLn stderr $ "Found configuration file at `" ++ path ++ "`." -- TODO: add a `DEBUG` flag to torxakis.
       res <- decodeFileEither path
       case res of
         Left err   -> error (show err)
@@ -155,3 +158,5 @@ findConfigFile :: IO (Maybe FilePath)
 findConfigFile = do
   home <- getHomeDirectory
   findM doesFileExist [configFileName, home </> configFileName]
+
+

--- a/sys/server/src/TxsServerConfig.hs
+++ b/sys/server/src/TxsServerConfig.hs
@@ -143,10 +143,10 @@ loadConfigFromFile = do
   mPath <- findConfigFile
   case mPath of
     Nothing -> do
-      hPutStrLn stderr "No configuration file found."  -- TODO: add a `DEBUG` flag to torxakis.
+      hPutStrLn stderr "No configuration file found."
       return Nothing
     Just path -> do
-      hPutStrLn stderr $ "Found configuration file at `" ++ path ++ "`." -- TODO: add a `DEBUG` flag to torxakis.
+      hPutStrLn stderr $ "Found configuration file at `" ++ path ++ "`."
       res <- decodeFileEither path
       case res of
         Left err   -> error (show err)


### PR DESCRIPTION
Added a `snap` folder that contains the information needed to build a `snap` package, which can be distributed to Linux systems. The README was updated accordingly.

@tretmans: see the instructions on the readme to see how `TorXakis` can be installed on Linux systems. Note that `snap` will create two executables: `torxakis.txsserver` and `torxakis.txsui`. I requested an alias to `txsserver` and `txsui` but this a manual procedure that somebody at Canonical has to approve :/ Hopefully it won't take long.

Closes #319 
Closes #216 