### PR TITLE
Improved Stautdef code

### DIFF
--- a/sys/behave/src/Expand.hs
+++ b/sys/behave/src/Expand.hs
@@ -200,7 +200,7 @@ expand chsets (BNbexpr we (StAut ini ve trns))  =  do
                                                            : [ cstrEqual (cstrVar ivar) (cstrConst wal) | (ivar, wal) <- exclams' ]
                                                            )
                                              )
-                       , ctnext    = BNbexpr (envwals',ivenv) (StAut to' ve' trns)
+                       , ctnext    = BNbexpr (envwals',ivenv) (StAut to' (Map.union ve' ve) trns)
                        }
 
 -- ----------------------------------------------------------------------------------------- --

--- a/sys/front/src/TxsHappy.y
+++ b/sys/front/src/TxsHappy.y
@@ -3835,11 +3835,11 @@ UpdateList      -- :: { VEnv }
                 --           : used objects shall be defined
               : {- empty -}
                 {  $$.synMaxUid    = $$.inhNodeUid
-                ;  $$ = Map.fromList [ (vid, cstrVar vid) | vid <- $$.inhStVarSigs ]
+                ;  $$ = Map.empty
                 }
               | "{" "}"
                 {  $$.synMaxUid    = $$.inhNodeUid
-                ;  $$ = Map.fromList [ (vid, cstrVar vid) | vid <- $$.inhStVarSigs ]
+                ;  $$ = Map.empty
                 }
               | Updates 
                 {  $1.inhNodeUid   = $$.inhNodeUid + 1
@@ -3847,11 +3847,7 @@ UpdateList      -- :: { VEnv }
                 ;  $1.inhSigs      = $$.inhSigs
                 ;  $1.inhVarSigs   = $$.inhVarSigs
                 ;  $1.inhStVarSigs = $$.inhStVarSigs
-                ;  $$ = let id = Map.fromList [ (vid, cstrVar vid)
-                                              | vid <- $$.inhStVarSigs
-                                              , vid `Map.notMember` $1
-                                              ]
-                         in $1 `Map.union` id
+                ;  $$ = $1
                 }
               | "{" Updates "}"
                 {  $2.inhNodeUid   = $$.inhNodeUid + 1
@@ -3859,11 +3855,7 @@ UpdateList      -- :: { VEnv }
                 ;  $2.inhSigs      = $$.inhSigs
                 ;  $2.inhVarSigs   = $$.inhVarSigs
                 ;  $2.inhStVarSigs = $$.inhStVarSigs
-                ;  $$ = let id = Map.fromList [ (vid, cstrVar vid)
-                                              | vid <- $$.inhStVarSigs
-                                              , vid `Map.notMember` $2
-                                              ]
-                         in $2 `Map.union` id
+                ;  $$ = $2
                 }
 
 Updates         -- :: { VEnv }
@@ -3880,7 +3872,7 @@ Updates         -- :: { VEnv }
               : Update
                 {  $1.inhNodeUid   = $$.inhNodeUid + 1
                 ;  $$.synMaxUid    = $1.synMaxUid
-                ;  $1.inhSigs  = $$.inhSigs
+                ;  $1.inhSigs      = $$.inhSigs
                 ;  $1.inhVarSigs   = $$.inhVarSigs
                 ;  $1.inhStVarSigs = $$.inhStVarSigs
                 ;  $$ = $1


### PR DESCRIPTION
1. Checking of uninitialized variables works
   (by removing the identical mapping)

2. Keep old values in Value Environment
   (which was realized by adding the identical mapping)

fixes #376 
fixes #251

Looking once more at the code: I just moved the Map.union ....