### PR TITLE
Fixed ReadWrite-HitAll7 test

### DIFF
--- a/test/examps/ReadWriteConflict/ReadWrite_Simulator.txscmd
+++ b/test/examps/ReadWriteConflict/ReadWrite_Simulator.txscmd
@@ -1,3 +1,4 @@
+param param_Sim_deltaTime 500
 simulator Model Sim
 sim 40
 exit


### PR DESCRIPTION
Set Sim_deltaTime to 500ms for RW-HitAll7

Fixes #375 