### PR TITLE
Fixed ReadWriteConflict-HitAll7 test

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test sqatt:examples-test --test-arguments="--skip=#long --skip=#model --match=Hit" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test sqatt:examples-test --test-arguments="--skip=#long --skip=#model --match=Read" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test sqatt:examples-test --test-arguments="--skip=#long --skip=#model --match=Read" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test --test-arguments="--skip=#long --skip=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test --test-arguments="--skip=#long --skip=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test sqatt:examples-test --test-arguments="--skip=#long --skip=#model --match=Hit" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -

--- a/test/examps/ReadWriteConflict/ReadWrite_Simulator.txscmd
+++ b/test/examps/ReadWriteConflict/ReadWrite_Simulator.txscmd
@@ -1,3 +1,4 @@
+param param_Sim_deltaTime 500
 simulator Model Sim
 sim 40
 exit

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -387,7 +387,7 @@ mkTest :: Maybe FilePath -> RunnableExample -> Test ()
 mkTest mLogDir (ExampleWithSut ex cSUT args) = do
   res <- liftIO $
     runConcurrently $  runSUTWithTimeout mLogDir cSUT args
-                   <|> runTxsWithExample mLogDir ex 0.25
+                   <|> runTxsWithExample mLogDir ex 0.1
   case res of
     Left txsErr -> throwError txsErr
     Right ()    -> return ()

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -343,20 +343,14 @@ runInproc :: Maybe FilePath   -- ^ Directory where the logs will be stored, or @
           -> [Text]           -- ^ Command arguments.
           -> Shell Line       -- ^ Lines to be input to the command.
           -> IO (Either SqattError ())
-runInproc mLogDir cmd cmdArgs procInput =
-  case mLogDir of
-    Nothing -> do
-      res <- try $ sh $ inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
-      case res of
-        Left unhandledException ->
-          return $ Left $ UnexpectedException . T.pack . show $ unhandledException
-        Right () -> return $ Right ()
-    Just logDir -> do
-      res <- try $ output logDir $ either id id <$> inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
-      case res of
-        Left unhandledException ->
-          return $ Left $ UnexpectedException . T.pack . show $ unhandledException
-        Right () -> return $ Right ()
+runInproc mLogDir cmd cmdArgs procInput = do
+  res <- case mLogDir of
+    Nothing -> try $ sh $ inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
+    Just logDir -> try $ output logDir $ either id id <$> inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
+  case res of
+    Left unhandledException ->
+      return $ Left $ UnexpectedException . T.pack . show $ unhandledException
+    Right () -> return $ Right ()
 
 -- | Run a process without input. See `runInproc`.
 --

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -32,6 +32,7 @@ module Sqatt
 where
 
 import           Control.Applicative
+import           Control.Arrow
 import           Control.Concurrent.Async
 import           Control.Exception
 import           Control.Foldl
@@ -344,13 +345,10 @@ runInproc :: Maybe FilePath   -- ^ Directory where the logs will be stored, or @
           -> Shell Line       -- ^ Lines to be input to the command.
           -> IO (Either SqattError ())
 runInproc mLogDir cmd cmdArgs procInput = do
-  res <- case mLogDir of
+  testResult <- case mLogDir of
     Nothing -> try $ sh $ inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
     Just logDir -> try $ output logDir $ either id id <$> inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
-  case res of
-    Left unhandledException ->
-      return $ Left $ UnexpectedException . T.pack . show $ unhandledException
-    Right () -> return $ Right ()
+  return $ left (UnexpectedException . T.pack . show) testResult
 
 -- | Run a process without input. See `runInproc`.
 --

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -346,17 +346,17 @@ runInproc :: Maybe FilePath   -- ^ Directory where the logs will be stored, or @
 runInproc mLogDir cmd cmdArgs procInput =
   case mLogDir of
     Nothing -> do
-      res <- try $ sh $ inprocWithErr cmd cmdArgs procInput
+      res <- try $ sh $ inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
       case res of
         Left unhandledException ->
           return $ Left $ UnexpectedException . T.pack . show $ unhandledException
-        Right () -> return res
+        Right () -> return $ Right ()
     Just logDir -> do
-      res <- try $ output logDir $ either id id <$> inprocWithErr cmd cmdArgs procInput
+      res <- try $ output logDir $ either id id <$> inprocWithErr cmd cmdArgs procInput :: IO (Either SomeException ())
       case res of
         Left unhandledException ->
           return $ Left $ UnexpectedException . T.pack . show $ unhandledException
-        Right () -> return res
+        Right () -> return $ Right ()
 
 -- | Run a process without input. See `runInproc`.
 --


### PR DESCRIPTION
Set Sim_deltaTime to 500ms for Simulator in RW-HitAll7

Adding an extra command for Simulator (setting param_Sim_deltaTime) caused it to start a bit late, resulted in Tester starting before Simulator is ready, which causes it to fail due to absence of SUT.
Solved it by adding 100ms delay for Tester when there's a SUT on the other side.
Please review @capitanbatata @pjljvandelaar 

Fixes #375
Fixes #386