### PR TITLE
Remove the duplicates from the TorXakis command history

### DIFF
--- a/sys/ui/src/UI.hs
+++ b/sys/ui/src/UI.hs
@@ -121,10 +121,8 @@ connectToServer :: FilePath -- ^ Log directory.
                 -> IO (Handle, Maybe TxsServerInfo)
 connectToServer logDir sAddr = do
     (p, mTsi) <- findTxsServer logDir (portId sAddr)
-    putStrLn $ "Connecting to: " ++ show p
     threadDelay 1000000    -- 1 sec delay on trying to connect
     hc <- connectTo (hostName sAddr) p
-    putStrLn "Connection established."
     hSetBuffering hc NoBuffering
     hSetEncoding hc latin1
     return (hc, mTsi)


### PR DESCRIPTION
When a new line is entered in the TorXakis UI, all the duplicates of that line are removed. The line is stored in the history with the leading and trailing whitespaces trimmed down.

Fixes #402.
Fixes #400.