### PR TITLE
Disabled GHC optimizations front

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,7 @@ before_build:
 - ps: $env:CACHE_DIR_REL = $CACHE_DIR_REL
 
 build_script:
-- stack install --pedantic --install-ghc --test --fast --no-terminal --stack-root %STACK_ROOT%
+- stack install --pedantic --install-ghc --test --no-terminal --stack-root %STACK_ROOT%
 
 # after_build:
 # -

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-stack install --pedantic --install-ghc --haddock --test --fast --stack-yaml stack_linux.yaml --work-dir $CACHE_DIR_REL/.stack-work --stack-root $CACHE_DIR/.stack --allow-different-user
+stack install --pedantic --install-ghc --haddock --test --stack-yaml stack_linux.yaml --work-dir $CACHE_DIR_REL/.stack-work --stack-root $CACHE_DIR/.stack --allow-different-user

--- a/sys/front/front.cabal
+++ b/sys/front/front.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:      TxsAlex
                       , TxsHappy
   
-  ghc-options:         -Werror -O2 -optc-O3 -optc-ffast-math -Wall
+  ghc-options:         -Werror -Wall -O0
   
   build-tools:          alex
                       , happy

--- a/sys/front/front.cabal
+++ b/sys/front/front.cabal
@@ -18,7 +18,7 @@ library
   exposed-modules:      TxsAlex
                       , TxsHappy
   
-  ghc-options:         -Werror -Wall -O0
+  ghc-options:         -Werror -Wall -O0 -optc-O3 -optc-ffast-math
   
   build-tools:          alex
                       , happy


### PR DESCRIPTION
Keeps C compiler optimizations
Removes --fast flag from CI build scripts

See https://github.com/TorXakis/TorXakis/issues/40#issuecomment-347473097
And [Benchmarks.pdf](https://github.com/TorXakis/TorXakis/files/1509335/Benchmarks.pdf)

This is a workaround for #40 
Related to #454 