### PR TITLE
Cache .stack-work folder in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -75,7 +75,8 @@ environment:
     STACK_ROOT: c:\TorXakis\.stack
 
 cache:
-- .stack -> .stack.yaml
+- .stack
+- .stack-work -> .stack.yaml
 - .cache
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2.installed'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,12 +76,12 @@ environment:
 
 cache:
 - .stack
-- .stack-work -> .stack.yaml
 - .cache
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2.installed'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20150512.installed'
+- .stack-work -> .stack.yaml
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ version: pre-0.5.0.{build}.{branch}
     # - develop
     # - /^hotfix.*$/
 
+
 init:
 - ps: Write-Host Starting init at $(Get-Date)
 - ps: $env:Path += ";C:\Program Files\Git\mingw64\bin"


### PR DESCRIPTION
Now that we use _ghc-integersimple_ for both _TorXakis_ and _sqatt_, we have enough space in AppVeyor cache for `.stack-work` folder. Caching it will prevent AppVeyor from building all packages for every build.
  