### PR TITLE
Updated Z3 to 4.6.0 and CVC4 to 20180306-nightly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,14 +35,14 @@ install:
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\cvc4.exe")) {
         # obtain the cvc4 executable
-        curl -OutFile $("$CACHE_DIR\cvc4.exe") https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.5/cvc4-1.5-win32-opt.exe -Verbose
+        curl -OutFile $("$CACHE_DIR\cvc4.exe") https://github.com/TorXakis/Dependencies/releases/download/cvc4-20180306/cvc4-20180306-win32-opt.exe -Verbose
     } else {
         Write-Host "cvc4.exe found.";
     }
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\z3")) {
         # install z3
-        curl -OutFile z3.zip https://github.com/TorXakis/Dependencies/releases/download/z3-4.5.1/z3-4.5.1.059bad909ad4-x64-win_20170905.zip -Verbose
+        curl -OutFile z3.zip https://github.com/TorXakis/Dependencies/releases/download/z3-4.6.0/z3-4.6.0-x64-win.zip -Verbose
         mkdir $CACHE_DIR\z3
         7z x $("-o${CACHE_DIR}\z3\") z3.zip
     } else {

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -21,30 +21,30 @@ else
     curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C $CACHE_DIR/bin '*/stack'
 fi
 
-if [ -f $CACHE_DIR/bin/cvc4 ]
+if [ -f $CACHE_DIR/bin/cvc4 ] && [ -e $CACHE_DIR/bin/cvc4-20180306 ]
 then
     echo "$CACHE_DIR/bin/cvc4 found in cache."
 else
-    curl -L -O https://github.com/TorXakis/Dependencies/releases/download/v0.3.0_linux/cvc4-1.5-x86_64-linux-opt
-    # Making symbolic links to the cvc4 executable to get the build working
-    # Using cvc4 as executable name to avoid having to update the configuration file in CI.
-    ln -s cvc4-1.5-x86_64-linux-opt cvc4
-    mv cvc4* $CACHE_DIR/bin
-    chmod +x $CACHE_DIR/bin/cvc4*
+    echo "cvc4 not found in cache or different version than 20180306"
+    rm $CACHE_DIR/bin/cvc4*
+    curl -L https://github.com/TorXakis/Dependencies/releases/download/cvc4-20180306/cvc4-20180306-x86_64-linux-opt -o cvc4
+    mv cvc4 $CACHE_DIR/bin
+    chmod +x $CACHE_DIR/bin/cvc4
+    touch $CACHE_DIR/bin/cvc4-20180306
 fi
 
-if [ -d $CACHE_DIR/z3 ] && [ -e $CACHE_DIR/z3/build-059bad909ad4 ]
+if [ -d $CACHE_DIR/z3 ] && [ -e $CACHE_DIR/z3/z3-4.6.0 ]
 then
-    echo "$CACHE_DIR/z3 build 059bad909ad4 is found in cache."
+    echo "$CACHE_DIR/z3 build 4.6.0 is found in cache."
 else
-    echo "z3 not found in cache or different version than 059bad909ad4"
+    echo "z3 not found in cache or different version than 4.6.0"
     rm $CACHE_DIR/z3 -rf
-    curl -L -O https://github.com/TorXakis/Dependencies/releases/download/z3-4.5.1/z3-4.5.1.059bad909ad4-x64-ubuntu-14.04_20170905.zip
+    curl -L -O https://github.com/TorXakis/Dependencies/releases/download/z3-4.6.0/z3-4.6.0-x64-ubuntu-14.04.zip
     CURDIR=$(pwd)
     mkdir $CACHE_DIR/z3 && cd $CACHE_DIR/z3
     Z3ZIP=$(ls $CURDIR/z3*.zip)
     unzip $Z3ZIP
     chmod +x ./bin/z3
-    touch ./build-059bad909ad4
+    touch ./z3-4.6.0
     cd $CURDIR
 fi


### PR DESCRIPTION
Added check for cached version of CVC4 (there was already one for Z3)

Closes #570 