### PR TITLE
moved to lts 11.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -85,16 +85,16 @@ cache:
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
-- ps: Write-Host Starting test at $(Get-Date)
-- ps: pushd test/sqatt
-- ps: |
-    $tryCount = 1
-    do {
-        Write-Host Try $tryCount
-        $tryCount++
-        cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml 2>&1"
-    } While ((!$?) -and ($tryCount -le 10))
-- stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml
-- ps: popd
+# - ps: Write-Host Starting test at $(Get-Date)
+# - ps: pushd test/sqatt
+# - ps: |
+#     $tryCount = 1
+#     do {
+#         Write-Host Try $tryCount
+#         $tryCount++
+#         cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml 2>&1"
+#     } While ((!$?) -and ($tryCount -le 10))
+# - stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml
+# - ps: popd
 
 # after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -85,16 +85,16 @@ cache:
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
-# - ps: Write-Host Starting test at $(Get-Date)
-# - ps: pushd test/sqatt
-# - ps: |
-#     $tryCount = 1
-#     do {
-#         Write-Host Try $tryCount
-#         $tryCount++
-#         cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml 2>&1"
-#     } While ((!$?) -and ($tryCount -le 10))
-# - stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml
-# - ps: popd
+- ps: Write-Host Starting test at $(Get-Date)
+- ps: pushd test/sqatt
+- ps: |
+    $tryCount = 1
+    do {
+        Write-Host Try $tryCount
+        $tryCount++
+        cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml 2>&1"
+    } While ((!$?) -and ($tryCount -le 10))
+- stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml
+- ps: popd
 
 # after_test:

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.8
+resolver: lts-11.0
 ghc-variant: integersimple
 
 # User packages to be built.

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-11.1
 ghc-variant: integersimple
 
 # User packages to be built.

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-11.1
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.8
+resolver: lts-11.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/environment/stack.yaml
+++ b/test/environment/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-11.1
 ghc-variant: integersimple
 
 # User packages to be built.
@@ -43,9 +43,6 @@ ghc-variant: integersimple
 packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- text-1.2.2.2
-- hexpat-0.20.13
 
 # Override default flag values for local packages and extra-deps
 flags: 

--- a/test/environment/stack.yaml
+++ b/test/environment/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.7
+resolver: lts-11.0
 ghc-variant: integersimple
 
 # User packages to be built.

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-11.1
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -43,9 +43,6 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- Win32-2.3.1.1
-- unix-compat-0.4.3.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -19,7 +19,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.8
+resolver: lts-11.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/sqatt/stack_appveyor.yaml
+++ b/test/sqatt/stack_appveyor.yaml
@@ -13,7 +13,7 @@
 # to be used for project dependencies. For example:
 #
 # needed for cache space: same as torxakis
-resolver: lts-11.0
+resolver: lts-11.1
 ghc-variant: integersimple
 
 # User packages to be built.
@@ -38,9 +38,6 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- Win32-2.3.1.1
-- unix-compat-0.4.3.1
 
 # Override default flag values for local packages and extra-deps
 flags: 

--- a/test/sqatt/stack_appveyor.yaml
+++ b/test/sqatt/stack_appveyor.yaml
@@ -13,7 +13,7 @@
 # to be used for project dependencies. For example:
 #
 # needed for cache space: same as torxakis
-resolver: lts-10.8
+resolver: lts-11.0
 ghc-variant: integersimple
 
 # User packages to be built.


### PR DESCRIPTION
On [stackage](http://stackage.org) a new lts is released.

I tested it.
Found one issue: don't know whether it reproduces.
```
Failures:

  src\Sqatt.hs:473:
  1) Examples.All, Customers and Orders, Customers & Orders Test
       expected: Right ()
        but got: Left (UnexpectedException "ExitFailure (-1)")

Randomized with seed 1664203401
```
It seems to be caused by the `java` SUT which terminates with an exception 
since the socket is closed by `Torxakis`.
```
> java.net.SocketException: Connection reset
>       at java.net.SocketInputStream.read(Unknown Source)
>       at java.net.SocketInputStream.read(Unknown Source)
>       at sun.nio.cs.StreamDecoder.readBytes(Unknown Source)
>       at sun.nio.cs.StreamDecoder.implRead(Unknown Source)
>       at sun.nio.cs.StreamDecoder.read(Unknown Source)
>       at java.io.InputStreamReader.read(Unknown Source)
>       at java.io.BufferedReader.fill(Unknown Source)
>       at java.io.BufferedReader.readLine(Unknown Source)
>       at java.io.BufferedReader.readLine(Unknown Source)
>       at CustomersOrders.lambda$getInputThread$1(CustomersOrders.java:87)
>       at java.lang.Thread.run(Unknown Source)
> java.net.SocketException: Connection reset
>       at java.net.SocketInputStream.read(Unknown Source)
>       at java.net.SocketInputStream.read(Unknown Source)
```
Is something changed in the libraries we use?
If so, we might have to change sqatt ;-(