### PR TITLE
Add more options for inlining

### DIFF
--- a/sys/defs/src/BehExprDefs.hs
+++ b/sys/defs/src/BehExprDefs.hs
@@ -20,7 +20,7 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE ViewPatterns       #-}
 module BehExprDefs
-( 
+(
   -- * Behaviour Expression type and view
   BExprView(..)
 , BExpr
@@ -81,7 +81,7 @@ data BExprView = ActionPref  ActOffer BExpr
                | StAut       StatId VEnv [Trans]
   deriving (Eq,Ord,Read,Show, Generic, NFData, Data)
 instance Resettable BExprView
-    where 
+    where
 --        reset (Choice bs)       = Choice (Set.toAscList (Set.fromList (reset bs))) -- reorder to ensure invariant
 --        reset x                 = over uniplate reset x
         reset (ActionPref a b)  = ActionPref (reset a) (reset b)
@@ -122,9 +122,10 @@ stop = BExpr (Choice [])
 
 -- | Create an ActionPrefix behaviour expression.
 actionPref :: ActOffer -> BExpr -> BExpr
-actionPref a b = BExpr (ActionPref a b)
-                    Vconst (Cbool False)    -> stop
-                    _                       -> BExpr (ActionPref a b)
+actionPref = \a b ->
+    case ValExpr.view (constraint a) of
+        Vconst (Cbool False) -> stop
+        _                    -> BExpr (ActionPref a b)
 
 -- | Create a guard behaviour expression.
 guard :: VExpr -> BExpr -> BExpr
@@ -135,20 +136,20 @@ guard = \v b -> BExpr (Guard v b)
 choice :: [BExpr] -> BExpr
 choice l = let s = flattenChoice l
                l' = Set.toAscList s       -- All elements in a set are distinct
-             in 
+             in
                 case l' of
                     []  -> stop
                     [a] -> a
                     _   -> BExpr (Choice l')
-    where 
+    where
         -- 1. nesting of choices are flatten
-        --    (p ## q) ## r == p ## q ## r 
+        --    (p ## q) ## r == p ## q ## r
         --    see https://wiki.haskell.org/Smart_constructors#Runtime_Optimisation_:_smart_constructors for inspiration for this implementation
         -- 2. elements in a set are distinctive
         --    hence p ## p == p
         flattenChoice :: [BExpr] -> Set.Set BExpr
         flattenChoice l' = Set.unions $ map fromBExpr l'
-        
+
         fromBExpr :: BExpr -> Set.Set BExpr
         fromBExpr (BehExprDefs.view -> Choice l') = Set.fromDistinctAscList l'
         fromBExpr x                               = Set.singleton x
@@ -164,7 +165,7 @@ parallel cs bs = let fbs = flattenParallel bs
         --    see https://wiki.haskell.org/Smart_constructors#Runtime_Optimisation_:_smart_constructors for inspiration for this implementation
         flattenParallel :: [BExpr] -> [BExpr]
         flattenParallel = concatMap fromBExpr
-        
+
         fromBExpr :: BExpr -> [BExpr]
         fromBExpr (BehExprDefs.view -> Parallel pcs pbs) | Set.fromList cs == Set.fromList pcs  = pbs
         fromBExpr bexpr                                                                         = [bexpr]

--- a/sys/defs/src/BehExprDefs.hs
+++ b/sys/defs/src/BehExprDefs.hs
@@ -114,7 +114,7 @@ instance Resettable BExpr
 isStop :: BExpr -> Bool
 isStop (BehExprDefs.view -> Choice []) = True
 isStop _                               = False
-
+-- see https://downloads.haskell.org/~ghc/7.0.2/docs/html/users_guide/pragmas.html for inlining differences of function definitions
 -- | Create a Stop behaviour expression.
 --   The Stop behaviour is equal to dead lock.
 stop :: BExpr
@@ -122,13 +122,13 @@ stop = BExpr (Choice [])
 
 -- | Create an ActionPrefix behaviour expression.
 actionPref :: ActOffer -> BExpr -> BExpr
-actionPref a b = case ValExpr.view (constraint a) of
+actionPref a b = BExpr (ActionPref a b)
                     Vconst (Cbool False)    -> stop
                     _                       -> BExpr (ActionPref a b)
 
 -- | Create a guard behaviour expression.
 guard :: VExpr -> BExpr -> BExpr
-guard v b = BExpr (Guard v b)
+guard = \v b -> BExpr (Guard v b)
 
 -- | Create a choice behaviour expression.
 --  A choice combines zero or more behaviour expressions.
@@ -169,37 +169,34 @@ parallel cs bs = let fbs = flattenParallel bs
         fromBExpr (BehExprDefs.view -> Parallel pcs pbs) | Set.fromList cs == Set.fromList pcs  = pbs
         fromBExpr bexpr                                                                         = [bexpr]
 
-
-
-
 -- | Create an enable behaviour expression.
 enable :: BExpr -> [ChanOffer] -> BExpr -> BExpr
-enable b1 cs b2 = BExpr (Enable b1 cs b2)
+enable = \b1 cs b2 -> BExpr (Enable b1 cs b2)
 
 -- | Create a disable behaviour expression.
 disable :: BExpr -> BExpr -> BExpr
-disable b1 b2 = BExpr (Disable b1 b2)
+disable = \b1 b2 -> BExpr (Disable b1 b2)
 
 -- | Create an interrupt behaviour expression.
 interrupt :: BExpr -> BExpr -> BExpr
-interrupt b1 b2 = BExpr (Interrupt b1 b2)
+interrupt = \b1 b2 -> BExpr (Interrupt b1 b2)
 
 -- | Create a process instantiation behaviour expression.
 procInst :: ProcId -> [ChanId] -> [VExpr] -> BExpr
-procInst p cs vs = BExpr (ProcInst p cs vs)
+procInst = \p cs vs -> BExpr (ProcInst p cs vs)
 
 -- | Create a hide behaviour expression.
 --   The given set of channels is hidden for its environment.
 hide :: [ChanId] -> BExpr -> BExpr
-hide cs b = BExpr (Hide cs b)
+hide = \cs b -> BExpr (Hide cs b)
 
 -- | Create a Value Environment behaviour expression.
 valueEnv :: VEnv -> BExpr -> BExpr
-valueEnv v b = BExpr (ValueEnv v b)
+valueEnv = \v b -> BExpr (ValueEnv v b)
 
 -- | Create a State Automaton behaviour expression.
 stAut :: StatId -> VEnv -> [Trans] -> BExpr
-stAut s v ts = BExpr (StAut s v ts)
+stAut = \s v ts -> BExpr (StAut s v ts)
 
 -- | ActOffer
 -- Offer on multiple channels with constraints

--- a/sys/valexpr/src/ValExprImpls.hs
+++ b/sys/valexpr/src/ValExprImpls.hs
@@ -98,7 +98,7 @@ import           Variable
 -- | Create a function call.
 -- Preconditions are /not/ checked.
 cstrFunc :: (Variable v, Variable w) => Map.Map FuncId (FuncDef v) -> FuncId -> [ValExpr w] -> ValExpr w
-cstrFunc fis fi arguments =
+cstrFunc = \fis fi arguments ->
     case Map.lookup fi fis of
         Nothing ->
             -- When implementing the body of a recursive function, a function
@@ -115,9 +115,9 @@ cstrFunc fis fi arguments =
 -- | Apply ADT Constructor of constructor with CstrId and the provided arguments (the list of value expressions).
 -- Preconditions are /not/ checked.
 cstrCstr :: CstrId -> [ValExpr v] -> ValExpr v
-cstrCstr c a = if all isConst a
-                then cstrConst (Cstr c (map (\(view -> Vconst v) -> v) a))
-                else ValExpr (Vcstr c a)
+cstrCstr = \c a -> if all isConst a
+                    then cstrConst (Cstr c (map (\(view -> Vconst v) -> v) a))
+                    else ValExpr (Vcstr c a)
 
 -- | Is the provided value expression made by the ADT constructor with CstrId?
 -- Preconditions are /not/ checked.
@@ -418,7 +418,7 @@ cstrStrInRe s r                                                      = ValExpr (
 
 -- | Create a call to a predefined function as a value expression.
 cstrPredef :: PredefKind -> FuncId -> [ValExpr v] -> ValExpr v
-cstrPredef p f a = ValExpr (Vpredef p f a)
+cstrPredef = \p f a -> ValExpr (Vpredef p f a)
 
 -- | Substitute variables by value expressions in a value expression.
 --


### PR DESCRIPTION
Moreover, GHC will only inline the function if it is fully applied,
where "fully applied" means applied to as many arguments as appear
(syntactically) on the LHS of the function definition.

see
https://downloads.haskell.org/~ghc/7.0.3/docs/html/users_guide/pragmas.html

so made some functions have less arguments on LHS

Inspired by #641 
I am curious if it really speeds up....