### PR TITLE
Removed the `-Wwarn -Wcompat` warning from `valexpr`.

### DIFF
--- a/sys/valexpr/src/Id.hs
+++ b/sys/valexpr/src/Id.hs
@@ -80,7 +80,7 @@ instance (Resettable a, Resettable b) => Resettable (a, b) where
 instance (Ord a, Resettable a) => Resettable (Set a) where
     reset = Set.fromList . (reset <$>) . Set.toList
 
-instance (Ord k, Ord v, Resettable k, Resettable v) => Resettable (Map k v) where
+instance (Ord k, Resettable k, Resettable v) => Resettable (Map k v) where
     reset = Map.fromList . (reset <$>) . Map.toList
 
 class GResettable f where

--- a/sys/valexpr/src/Product.hs
+++ b/sys/valexpr/src/Product.hs
@@ -54,7 +54,8 @@ import           Control.DeepSeq
 import           Data.Data
 import           Data.Foldable   hiding (product)
 import qualified Data.Map.Strict as Map
-import           Data.Monoid
+import           Data.Monoid     hiding ((<>))
+import           Data.Semigroup
 import           GHC.Generics    (Generic)
 import           Prelude         hiding (product)
 
@@ -88,9 +89,12 @@ instance Applicative ProductTerm where
     pure = ProductTerm
     fa <*> a = ProductTerm $ factor fa (factor a)
 
+instance Num a => Semigroup (ProductTerm a ) where
+    pt0 <> pt1 = pure (*) <*> pt0 <*> pt1
+
 instance Num a => Monoid (ProductTerm a) where
     mempty = pure 1
-    pt0 `mappend` pt1 = pure (*) <*> pt0 <*> pt1
+    mappend = (<>)
 
 instance TermWrapper ProductTerm where
     wrap = ProductTerm

--- a/sys/valexpr/src/Sum.hs
+++ b/sys/valexpr/src/Sum.hs
@@ -44,7 +44,8 @@ module Sum
 import           Control.DeepSeq
 import           Data.Data
 import           Data.Foldable   hiding (sum)
-import           Data.Monoid     ((<>))
+import           Data.Monoid     hiding ((<>))
+import           Data.Semigroup  (Semigroup, (<>))
 import           FreeMonoidX     (FreeMonoidX, IntMultipliable, TermWrapper,
                                   (<.>))
 import qualified FreeMonoidX     as FMX
@@ -74,9 +75,12 @@ newtype SumTerm a = SumTerm { summand :: a }
 
 instance (Resettable a) => Resettable (SumTerm a)
 
+instance Num a => Semigroup (SumTerm a) where
+    (SumTerm x) <> (SumTerm y) = SumTerm $ x + y
+
 instance Num a => Monoid (SumTerm a) where
     mempty = SumTerm 0
-    (SumTerm x) `mappend` (SumTerm y) = SumTerm $ x + y
+    mappend = (<>)
 
 instance TermWrapper SumTerm where
     wrap = SumTerm


### PR DESCRIPTION
Required by https://github.com/TorXakis/TorXakis/issues/691