### PR TITLE
added functionality to show functions

### DIFF
--- a/sys/core/src/TxsCore.hs
+++ b/sys/core/src/TxsCore.hs
@@ -899,6 +899,8 @@ txsShow item nm  = do
                                                      (TxsDefs.purpDefs tdefs)
               ("procdef"  ,_) -> return $ nm2string nm TxsDefs.IdProc TxsDefs.DefProc
                                                      (TxsDefs.procDefs tdefs)
+              ("funcdef"  ,_) -> return $ nm2string nm TxsDefs.IdFunc TxsDefs.DefFunc
+                                                     (TxsDefs.funcDefs tdefs)
               _ -> do IOC.putMsgs [ EnvData.TXS_CORE_USER_ERROR "nothing to be shown 1" ]
                       return "\n"
       _ -> case (item,nm) of
@@ -915,6 +917,8 @@ txsShow item nm  = do
                                                      (TxsDefs.purpDefs tdefs)
               ("procdef"  ,_)  -> return $ nm2string nm TxsDefs.IdProc TxsDefs.DefProc
                                                      (TxsDefs.procDefs tdefs)
+              ("funcdef"  ,_) -> return $ nm2string nm TxsDefs.IdFunc TxsDefs.DefFunc
+                                                     (TxsDefs.funcDefs tdefs)
               _ -> do IOC.putMsgs [ EnvData.TXS_CORE_USER_ERROR "nothing to be shown 2" ]
                       return "\n"
 

--- a/sys/server/src/TxsServer.hs
+++ b/sys/server/src/TxsServer.hs
@@ -845,6 +845,7 @@ cmdShow args = do
                 ["mapperdef",nm      ] -> lift $ TxsCore.txsShow "mapperdef" nm
                 ["purpdef"  ,nm      ] -> lift $ TxsCore.txsShow "purpdef"   nm
                 ["procdef"  ,nm      ] -> lift $ TxsCore.txsShow "procdef"   nm
+                ["funcdef"  ,nm      ] -> lift $ TxsCore.txsShow "funcdef"   nm
                 ["cnect"             ] -> return $ let (_, _, towhdls ) = IOS.tow envs
                                                        (_, _, frowhdls) = IOS.frow envs
                                                     in TxsShow.fshow (towhdls ++ frowhdls)


### PR DESCRIPTION
As I user I would like to see how my functions are internally represented since TorXakis performance term rewriting.

For example, how are the following functions internally represented
```
FUNCDEF alt1 (p,q,r :: Bool) :: Bool ::=
    (q => p) /\ (not(q) => r)
ENDDEF

FUNCDEF alt2 (p,q,r :: Bool) :: Bool ::=
    (q /\ p) \/ (not(q) /\ r)
ENDDEF
```
which described two alternatives for ITE (see https://github.com/TorXakis/TorXakis/wiki/IteValExpr).

With this change that works:
```
 show funcdef alt1
  ( alt1, FUNCTION
  [ p q r ]
  ::=
  ((not ((q /\ (not (p) ) )) ) /\ (not (((not (q) ) /\ (not (r) ) )) ) )
  )

 show funcdef alt2
  ( alt2, FUNCTION
  [ p q r ]
  ::=
  (not (((not ((p /\ q )) ) /\ (not ((r /\ (not (q) ) )) ) )) )
  )
```
