### PR TITLE
robustness improvement

### DIFF
--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -272,7 +272,7 @@ getCPOptsIO :: Maybe FilePath -> IO [Text]
 getCPOptsIO Nothing         = return []
 getCPOptsIO (Just filePath) = case toText filePath of
                                 Left apprPath ->
-                                  throw $ FilePathError $
+                                  throwIO $ FilePathError $
                                   "Cannot decode " <> apprPath <> " properly"
                                 Right path ->
                                   return ["-cp", path]


### PR DESCRIPTION
Parallel and Concurrent Programming in Haskell - Simon Marlow
Page 150: It is always better to use throwIO rather than throw in the IO
monad because throwIO guarantees strict ordering with respect to other
IO operations, whereas throw does not.