### PR TITLE
Fix/txs compiler improvements

### DIFF
--- a/sys/txs-compiler/package.yaml
+++ b/sys/txs-compiler/package.yaml
@@ -24,6 +24,11 @@ ghc-options:
 
 library:
   source-dirs: src
+  exposed-modules:
+  - TorXakis.Compiler
+  - TorXakis.Compiler.Error
+  - TorXakis.Parser  
+  - TorXakis.Compiler.MapsTo
   dependencies:
   - text
   - parsec

--- a/sys/txs-compiler/src/TorXakis/Parser/Data.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/Data.hs
@@ -13,7 +13,7 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE TypeFamilies           #-}
 --------------------------------------------------------------------------------
 -- |
--- Module      :  TorXakis.Compiler.Error
+-- Module      :  TorXakis.Parser.Data
 -- Copyright   :  (c) TNO and Radboud University
 -- License     :  BSD3 (see the file license.txt)
 --


### PR DESCRIPTION
Restricts the modules that are exposed from the `txs-compiler`.