### PR TITLE
yices is more strict in the ordering

### DIFF
--- a/sys/solve/src/SMTInternal.hs
+++ b/sys/solve/src/SMTInternal.hs
@@ -248,8 +248,8 @@ getInfo info = do
 
 init :: SMT ()
 init  =  do
-    put "(set-logic ALL)"
     put "(set-option :produce-models true)"
+    put "(set-logic ALL)"
     put "(set-info :smt-lib-version 2.5)"
     putT basicDefinitionsSMT
     return ()


### PR DESCRIPTION
Changed order since old order resulted in:
(:name "Yices")
(:version "2.6.0")
(error "option :produce-models can't be set now. It must be set before (set-logic ...)")

While cvc4 and z3 also accept the other order!