### PR TITLE
Issue/cache appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -88,7 +88,7 @@ cache:
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
-- ps: Write-Host $(dir -Recurse %LOCALAPPDATA%\Programs\stack\x86_64-windows)
+- dir /S %LOCALAPPDATA%\Programs\stack\x86_64-windows
 - ps: Write-Host Starting test at $(Get-Date)
 - ps: pushd test/sqatt
 - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,7 @@ install:
 before_build:
 - ps: $env:CACHE_DIR = $CACHE_DIR
 - ps: $env:CACHE_DIR_REL = $CACHE_DIR_REL
-- ps: Write-Host $(dir -Recurse '%LOCALAPPDATA%\Programs\stack\x86_64-windows)
+- ps: Write-Host $(dir -Recurse '%LOCALAPPDATA%\Programs\stack\x86_64-windows')
 
 build_script:
 - ps: Write-Host Starting build at $(Get-Date)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,6 +55,7 @@ install:
 before_build:
 - ps: $env:CACHE_DIR = $CACHE_DIR
 - ps: $env:CACHE_DIR_REL = $CACHE_DIR_REL
+- ps: Write-Host $(dir -Recurse '%LOCALAPPDATA%\Programs\stack\x86_64-windows)
 
 build_script:
 - ps: Write-Host Starting build at $(Get-Date)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,7 +55,6 @@ install:
 before_build:
 - ps: $env:CACHE_DIR = $CACHE_DIR
 - ps: $env:CACHE_DIR_REL = $CACHE_DIR_REL
-- ps: Write-Host $(dir -Recurse '%LOCALAPPDATA%\Programs\stack\x86_64-windows')
 
 build_script:
 - ps: Write-Host Starting build at $(Get-Date)
@@ -89,6 +88,7 @@ cache:
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
+- ps: Write-Host $(dir -Recurse %LOCALAPPDATA%\Programs\stack\x86_64-windows)
 - ps: Write-Host Starting test at $(Get-Date)
 - ps: pushd test/sqatt
 - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,13 +82,12 @@ cache:
 - .cache -> stack.yaml
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2.installed'
-- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys64'
-- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys64.installed'
+- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20180531'
+- '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20180531.installed'
 - .stack-work -> stack.yaml
 # - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 test_script:
-- dir /S %LOCALAPPDATA%\Programs\stack\x86_64-windows
 - ps: Write-Host Starting test at $(Get-Date)
 - ps: pushd test/sqatt
 - ps: |


### PR DESCRIPTION
msys2 is unpacked as msys64 in a directory with a more recent date.

fixes #759 