### PR TITLE
extended benchmark with dynamic process creation

### DIFF
--- a/test/sqatt/data/bench/Dynamic/distinguishByOrder.txs
+++ b/test/sqatt/data/bench/Dynamic/distinguishByOrder.txs
@@ -1,0 +1,26 @@
+PROCDEF produce [In; Out :: Int](n :: Int) ::=
+    In >-> ( Out ! n ||| produce [In,Out](n+1) )
+ENDDEF
+
+PROCDEF communicate [In :: Int; Out] (n :: Int) ::=
+    In ! n | Out >-> communicate[In, Out] (n+1)
+ENDDEF
+
+PROCDEF p [In, Out]() ::=
+    HIDE [Chan :: Int] IN
+            produce [In, Chan](1)
+        |[ Chan ]|
+            communicate [Chan, Out](1)
+    NI
+ENDDEF
+
+CHANDEF Channels ::=  In, Out
+ENDDEF
+
+MODELDEF Model ::=
+    CHAN IN    In
+    CHAN OUT   Out
+
+    BEHAVIOUR  
+        p[In, Out]()
+ENDDEF

--- a/test/sqatt/data/bench/Dynamic/distinguishByOrder.txs
+++ b/test/sqatt/data/bench/Dynamic/distinguishByOrder.txs
@@ -1,3 +1,8 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
 PROCDEF produce [In; Out :: Int](n :: Int) ::=
     In >-> ( Out ! n ||| produce [In,Out](n+1) )
 ENDDEF

--- a/test/sqatt/data/bench/Dynamic/distinguishByOrder.txscmd
+++ b/test/sqatt/data/bench/Dynamic/distinguishByOrder.txscmd
@@ -1,0 +1,3 @@
+stepper Model
+step 100
+exit

--- a/test/sqatt/data/bench/Dynamic/distinguishByOrder.txscmd
+++ b/test/sqatt/data/bench/Dynamic/distinguishByOrder.txscmd
@@ -1,3 +1,3 @@
 stepper Model
-step 100
+step 20
 exit

--- a/test/sqatt/data/bench/Dynamic/distinguishByValue.txs
+++ b/test/sqatt/data/bench/Dynamic/distinguishByValue.txs
@@ -1,3 +1,8 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
 PROCDEF p [In; Out :: Int](n :: Int) ::=
     In >-> ( Out ! n ||| p [In,Out](n+1) )
 ENDDEF

--- a/test/sqatt/data/bench/Dynamic/distinguishByValue.txs
+++ b/test/sqatt/data/bench/Dynamic/distinguishByValue.txs
@@ -1,0 +1,14 @@
+PROCDEF p [In; Out :: Int](n :: Int) ::=
+    In >-> ( Out ! n ||| p [In,Out](n+1) )
+ENDDEF
+
+CHANDEF Channels ::=  In; Out :: Int
+ENDDEF
+
+MODELDEF Model ::=
+    CHAN IN    In
+    CHAN OUT   Out
+
+    BEHAVIOUR  
+        p[In, Out](1)
+ENDDEF

--- a/test/sqatt/data/bench/Dynamic/distinguishByValue.txscmd
+++ b/test/sqatt/data/bench/Dynamic/distinguishByValue.txscmd
@@ -1,0 +1,3 @@
+stepper Model
+step 1000
+exit

--- a/test/sqatt/data/bench/Dynamic/distinguishByValue.txscmd
+++ b/test/sqatt/data/bench/Dynamic/distinguishByValue.txscmd
@@ -1,3 +1,3 @@
 stepper Model
-step 1000
+step 100
 exit

--- a/test/sqatt/data/bench/Dynamic/nonDistinguishing.txs
+++ b/test/sqatt/data/bench/Dynamic/nonDistinguishing.txs
@@ -1,3 +1,8 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
 PROCDEF p [In, Out]() ::=
     In >-> ( Out ||| p [In,Out]() )
 ENDDEF

--- a/test/sqatt/data/bench/Dynamic/nonDistinguishing.txs
+++ b/test/sqatt/data/bench/Dynamic/nonDistinguishing.txs
@@ -1,0 +1,15 @@
+PROCDEF p [In, Out]() ::=
+    In >-> ( Out ||| p [In,Out]() )
+ENDDEF
+
+CHANDEF Channels ::=  In
+                    ; Out
+ENDDEF
+
+MODELDEF Model ::=
+    CHAN IN    In
+    CHAN OUT   Out
+
+    BEHAVIOUR  
+        p[In, Out]()
+ENDDEF

--- a/test/sqatt/data/bench/Dynamic/nonDistinguishing.txscmd
+++ b/test/sqatt/data/bench/Dynamic/nonDistinguishing.txscmd
@@ -1,0 +1,3 @@
+stepper Model
+step 1000
+exit

--- a/test/sqatt/data/bench/Dynamic/nonDistinguishing.txscmd
+++ b/test/sqatt/data/bench/Dynamic/nonDistinguishing.txscmd
@@ -1,3 +1,3 @@
 stepper Model
-step 1000
+step 100
 exit

--- a/test/sqatt/sqatt.cabal
+++ b/test/sqatt/sqatt.cabal
@@ -22,6 +22,7 @@ library
                      , Integration.All
                      , ExploreModels.All
   other-modules:       Benchmarks.Choice
+                     , Benchmarks.Dynamic
                      , Benchmarks.Enable
                      , Benchmarks.Common
                      , Benchmarks.Hiding

--- a/test/sqatt/src/Benchmarks/All.hs
+++ b/test/sqatt/src/Benchmarks/All.hs
@@ -7,6 +7,7 @@ See LICENSE at root directory of this repository.
 module Benchmarks.All (allExamples, allBenchmarks) where
 
 import qualified Benchmarks.Choice          as Choice
+import qualified Benchmarks.Dynamic         as Dynamic
 import qualified Benchmarks.Enable          as Enable
 import qualified Benchmarks.Hiding          as Hiding
 import qualified Benchmarks.Parallel        as Parallel
@@ -18,6 +19,7 @@ import           Sqatt
 
 allExamples :: [TxsExampleSet]
 allExamples = [ Choice.benchmarksSet
+              , Dynamic.benchmarksSet
               , Enable.benchmarksSet
               , Hiding.benchmarksSet
               , Parallel.benchmarksSet

--- a/test/sqatt/src/Benchmarks/Dynamic.hs
+++ b/test/sqatt/src/Benchmarks/Dynamic.hs
@@ -1,0 +1,64 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Benchmarks.Dynamic
+-- Copyright   :  (c) TNO and Radboud University
+-- License     :  BSD3 (see the file license.txt)
+-- 
+-- Maintainer  :  pierre.vandelaar@tno.nl (ESI)
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Benchmarks in which processes are dynamically created/instantiated.
+-- Note: these benchmarks thus can NOT be transformed by LPE.
+-----------------------------------------------------------------------------
+module Benchmarks.Dynamic (benchmarksSet) where
+
+import           Benchmarks.Common
+import           Paths
+import           Prelude           hiding (FilePath)
+import           Sqatt
+
+benchDir :: FilePath
+benchDir = "Dynamic"
+
+nonDistinguishing :: TxsExample
+nonDistinguishing = emptyExample
+    { exampleName = "non distinguishing output"
+    , txsModelFiles = [ txsFilePath BenchTest benchDir "nonDistinguishing" ]
+    , txsCmdsFiles = [ seedSetupCmdFile
+                     , txsCmdPath BenchTest benchDir "nonDistinguishing"
+                     ]
+    , expectedResult = Pass
+    }
+
+distinguishByValue :: TxsExample
+distinguishByValue = emptyExample
+    { exampleName = "distinguishing output by Value"
+    , txsModelFiles = [ txsFilePath BenchTest benchDir "distinguishByValue" ]
+    , txsCmdsFiles = [ seedSetupCmdFile
+                     , txsCmdPath BenchTest benchDir "distinguishByValue"
+                     ]
+    , expectedResult = Pass
+    }
+
+distinguishByOrder :: TxsExample
+distinguishByOrder = emptyExample
+    { exampleName = "distinguishing output by Order"
+    , txsModelFiles = [ txsFilePath BenchTest benchDir "distinguishByOrder" ]
+    , txsCmdsFiles = [ seedSetupCmdFile
+                     , txsCmdPath BenchTest benchDir "distinguishByOrder"
+                     ]
+    , expectedResult = Pass
+    }
+
+benchmarksSet :: TxsExampleSet
+benchmarksSet = TxsExampleSet "Dynamic" [ nonDistinguishing
+                                        , distinguishByValue
+                                        , distinguishByOrder
+                                        ]


### PR DESCRIPTION
Although the real world benchmarks contained dynamic process
instantion/creation, it was absent as a primitive.

Added 3 cases.

The expected slowness of non-distinguising output was not observed!
distinguis by order was 10 times slower (so number of steps reduce by
factor of 10)