### PR TITLE
Issue/zero 777

### DIFF
--- a/sys/txs-compiler/src/TorXakis/Compiler.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler.hs
@@ -49,7 +49,7 @@ import qualified Data.Set                           as Set
 import           Data.Text                          (Text)
 
 import           BehExprDefs                        (Offer, chanIdIstep)
-import           ChanId                             (ChanId (ChanId))
+import           ChanId                             (ChanId)
 import qualified ChanId
 import           CstrId                             (CstrId)
 import           FuncDef                            (FuncDef)
@@ -65,14 +65,14 @@ import           SortId                             (SortId, sortIdBool,
                                                      sortIdString)
 import           StdTDefs                           (stdFuncTable, stdTDefs)
 import           TxsDefs                            (BExpr, ProcDef,
-                                                     ProcId (ProcId), TxsDefs,
+                                                     ProcId, TxsDefs,
                                                      chanid, cnectDefs,
                                                      fromList, funcDefs,
                                                      mapperDefs, modelDefs,
                                                      procDefs, purpDefs, union)
 import qualified TxsDefs                            (empty)
 import           ValExpr                            (ValExpr)
-import           VarId                              (VarId (VarId), varsort)
+import           VarId                              (VarId, varsort)
 import qualified VarId
 
 import           TorXakis.Compiler.Data             (CompilerM, getNextId,
@@ -387,13 +387,7 @@ compileToProcDefs mm pd = do
     pmsP <- getMap mm (pd ^. procs)  :: CompilerM (Map (Loc ProcDeclE) ProcInfo)
     pmsS <- getMap mm (pd ^. stauts) :: CompilerM (Map (Loc ProcDeclE) ProcInfo)
     let pms = pmsP <> pmsS
-        -- Remove the names from variable and channel id's.
-        -- NOTE: This won't be needed once https://github.com/TorXakis/TorXakis/issues/746 is fixed
-        pidsNN = anonymizePid . getPId <$> Map.elems pms
-        anonymizePid (ProcId n i cs vs e) = ProcId n i (anonymizeCid <$> cs) (anonymizeVid <$> vs) e
-        anonymizeCid (ChanId _ i sids) = ChanId "" i sids
-        anonymizeVid (VarId _ i sid) = VarId "" i sid
-    checkUnique (NoErrorLoc, Process, "Process") pidsNN
+    checkUnique (NoErrorLoc, Process, "Process") (getPId <$> Map.elems pms)
     procPDefMap  <- procDeclsToProcDefMap (pms :& mm) (pd ^. procs)
     stautPDefMap <- stautDeclsToProcDefMap (pms :& mm) (pd ^. stauts)
     return $ procPDefMap <> stautPDefMap

--- a/sys/txs-compiler/src/TorXakis/Compiler/Simplifiable.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Simplifiable.hs
@@ -52,7 +52,7 @@ import           TxsDefs         (ActOffer (ActOffer), BExpr, BExprView (ActionP
                                   stAut, valueEnv)
 import           ValExpr         (ValExpr,
                                   ValExprView (Vfunc, Vite, Vproduct, Vsum),
-                                  cstrITE, cstrProduct, cstrSum)
+                                  cstrITE, cstrFunc, cstrProduct, cstrSum)
 import qualified ValExpr
 import           VarId           (VarId)
 
@@ -67,7 +67,7 @@ class Simplifiable e where
              -> e
 
 instance Simplifiable (ValExpr VarId) where
-    simplify ft fns ex@(ValExpr.view -> Vfunc (FuncId n _ aSids rSid) vs) =
+    simplify ft fns ex@(ValExpr.view -> Vfunc (FuncId n i aSids rSid) vs) =
         -- NOTE: For now make the simplification only if "n" is a predefined
         -- symbol. Once compliance with the current `TorXakis` compiler is not
         -- needed we can remove this constraint and simplify further. However,
@@ -78,7 +78,7 @@ instance Simplifiable (ValExpr VarId) where
             sh <- Map.lookup n (toMap ft)
             h  <- Map.lookup (Signature aSids rSid) sh
             return $ h (simplify ft fns <$> vs)
-        else ex
+        else cstrFunc (Map.empty :: Map.Map FuncId (FuncDef VarId)) (FuncId n i aSids rSid) (simplify ft fns <$> vs)
     simplify ft fns (ValExpr.view -> Vite ex0 ex1 ex2) =
         cstrITE
         (simplify ft fns ex0)

--- a/sys/txs-compiler/test/data/success/SimpleFuncDefs.txs
+++ b/sys/txs-compiler/test/data/success/SimpleFuncDefs.txs
@@ -1,0 +1,34 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
+CONSTDEF
+    one :: Int ::= 1;
+    two :: String ::= "two"
+ENDDEF
+
+FUNCDEF const() :: Int ::=
+    2
+ENDDEF
+
+FUNCDEF inc(x :: Int) :: Int ::=
+    x + 1
+ENDDEF
+
+FUNCDEF incOne() :: Int ::=
+    inc(one)
+ENDDEF
+
+FUNCDEF incConst() :: Int ::=
+    inc(const())
+ENDDEF
+
+FUNCDEF doubleInc(x :: Int) :: Int ::=
+    inc(x) + 1
+ENDDEF
+
+FUNCDEF matchInc(s :: String; x :: Int) :: Int ::=
+    IF s == two THEN inc(x) ELSE x FI
+ENDDEF


### PR DESCRIPTION
fixes #777 

In the old compiler, the signature structure contains expressions that have to be replaced with their replacement (e.g. in the current example: zero by 0). Whenever the expression was encountered during parsing, the replacement happened immediately.

In the new compiler, this replacement is localized in simplify. In other words, first a structure that contains the expression to be replaced is built up (in this example containing zero). Then using simplify that structure is traversed to replace some expression by others (in this example, replace zero by 0). 

The bug was that the replacement was not executed everywhere.


