### PR TITLE
Modify the `HasTypedVars` instance for `ActOfferDecl`...

### DIFF
--- a/sys/txs-compiler/src/TorXakis/Compiler.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler.hs
@@ -64,9 +64,8 @@ import           SortId                             (SortId, sortIdBool,
                                                      sortIdInt, sortIdRegex,
                                                      sortIdString)
 import           StdTDefs                           (stdFuncTable, stdTDefs)
-import           TxsDefs                            (BExpr, ProcDef,
-                                                     ProcId, TxsDefs,
-                                                     chanid, cnectDefs,
+import           TxsDefs                            (BExpr, ProcDef, ProcId,
+                                                     TxsDefs, chanid, cnectDefs,
                                                      fromList, funcDefs,
                                                      mapperDefs, modelDefs,
                                                      procDefs, purpDefs, union)
@@ -227,7 +226,7 @@ compileParsedDefs parsedDefs = do
     let fdefsSHs = innerSigHandlerMap (fIds :& fdefs)
         allFSHs = stdSHs <> adtsSHs <> fdefsSHs
 
-    -- Generate a map from process declarations to their definitons.
+    -- Generate a map from process declarations to their definitions.
     pdefs <- compileToProcDefs (sIds :& cstrIds :& allFids :& allFSHs :& decls) parsedDefs
     checkUnique (NoErrorLoc, Channel, "Channel definition")
                 (chanDeclName <$> (parsedDefs ^. chdecls))

--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/ProcDef.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/ProcDef.hs
@@ -133,7 +133,6 @@ procDeclsToProcDefMap mm = gProcDeclsToProcDefMap emptyMpd
           let body = procDeclBody pd
               fss = dropHandler (innerMap mm)
               paramTypes = Map.fromList (fmap (second varsort) pvIds)
-
           bTypes  <- Map.fromList <$>
               inferVarTypes (  Map.fromList pvIds
                             :& mm

--- a/sys/txs-compiler/test/data/success/SimpleProcDefs.txs
+++ b/sys/txs-compiler/test/data/success/SimpleProcDefs.txs
@@ -664,3 +664,10 @@ PROCDEF hidder2[I, J, K :: Int]() ::=
         I ! v
     NI
 ENDDEF    
+
+-- | Test support for implicit variables introduced in (question mark) actions.
+--
+-- See https://github.com/TorXakis/TorXakis/issues/769#issuecomment-413872550
+PROCDEF varActionBinding[S, R :: Int]() ::=
+   S ? x [[ LET y = x IN True NI ]]
+ENDDEF


### PR DESCRIPTION
... so that the implicit variables introduced by input actions (question marks)
are taken into account when inferring the types of the variables in the guards.

Fix #769 