### PR TITLE
used platform to name stack.yml files consistently.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,7 +81,7 @@ cache:
 - .stack-root -> stack.yaml
 - .stack-work -> stack.yaml
 - .cache -> stack.yaml
-- test\sqatt\.stack-work -> test\sqatt\stack_appveyor.yaml
+- test\sqatt\.stack-work -> test\sqatt\stack.yaml
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\ghc-integersimple-8.2.2.installed'
 - '%LOCALAPPDATA%\Programs\stack\x86_64-windows\msys2-20180531'
@@ -96,9 +96,9 @@ test_script:
     do {
         Write-Host Try $tryCount
         $tryCount++
-        cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml 2>&1"
+        cmd /c "stack build --install-ghc --no-terminal --stack-root %STACK_ROOT% 2>&1"
     } While ((!$?) -and ($tryCount -le 10))
-- stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT% --stack-yaml stack_appveyor.yaml
+- stack test --test-arguments="--skip=#model" --no-terminal --stack-root %STACK_ROOT%
 - ps: popd
 
 # after_test:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test --test-arguments="--skip=#long --skip=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test --test-arguments="--skip=#long --skip=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user --stack-yaml stack_linux.yaml && cd -

--- a/ci/test_long.sh
+++ b/ci/test_long.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test --test-arguments="--match=#long" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test --test-arguments="--match=#long" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user --stack-yaml stack_linux.yaml && cd -

--- a/ci/test_models.sh
+++ b/ci/test_models.sh
@@ -2,4 +2,4 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-cd test/sqatt && stack test --test-arguments="--match=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user && cd -
+cd test/sqatt && stack test --test-arguments="--match=#model" --work-dir $CACHE_DIR_REL/test/.stack_work --stack-root $CACHE_DIR/.stack --allow-different-user --stack-yaml stack_linux.yaml && cd -

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -12,14 +12,9 @@
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
 #
-# resolver: lts-3.5
-# resolver: nightly-2015-09-21
-# resolver: ghc-7.10.2
-# resolver: ghcjs-0.1.0_ghc-7.10.2
-# resolver:
-#  name: custom-snapshot
-#  location: "./custom-snapshot.yaml"
+# needed for cache space: same as torxakis
 resolver: lts-11.17
+ghc-variant: integersimple
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -45,10 +40,18 @@ packages:
 # (e.g., acme-missiles-0.3)
 
 # Override default flag values for local packages and extra-deps
-flags: {}
+flags: 
+  text: 
+    integer-simple: true
+  hashable:
+    integer-gmp: false
+  integer-logarithms:
+    integer-gmp: false
+  scientific:
+    integer-simple: true
 
 # Extra package databases containing global packages
-extra-package-dbs: []
+extra-package-dbs:
 
 # Control whether we use the GHC we find on the path
 # system-ghc: true

--- a/test/sqatt/stack_linux.yaml
+++ b/test/sqatt/stack_linux.yaml
@@ -12,9 +12,14 @@
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
 #
-# needed for cache space: same as torxakis
+# resolver: lts-3.5
+# resolver: nightly-2015-09-21
+# resolver: ghc-7.10.2
+# resolver: ghcjs-0.1.0_ghc-7.10.2
+# resolver:
+#  name: custom-snapshot
+#  location: "./custom-snapshot.yaml"
 resolver: lts-11.17
-ghc-variant: integersimple
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,18 +45,10 @@ packages:
 # (e.g., acme-missiles-0.3)
 
 # Override default flag values for local packages and extra-deps
-flags: 
-  text: 
-    integer-simple: true
-  hashable:
-    integer-gmp: false
-  integer-logarithms:
-    integer-gmp: false
-  scientific:
-    integer-simple: true
+flags: {}
 
 # Extra package databases containing global packages
-extra-package-dbs:
+extra-package-dbs: []
 
 # Control whether we use the GHC we find on the path
 # system-ghc: true


### PR DESCRIPTION
fixes #783 : not a single file but clearer where yaml file is for:
basically you get integer_simple on windows.
For Linux platforms which don't support integer simple you have to use the stack_linux.yaml files.
