### PR TITLE
 Added Echo with Delay: a non-determinsitic model

### DIFF
--- a/examps/Echo/EchoDelay.txs
+++ b/examps/Echo/EchoDelay.txs
@@ -1,0 +1,33 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
+TYPEDEF List ::= Nil
+               | Cons{head::Int; tail::List}
+ENDDEF
+
+FUNCDEF add ( x :: Int; l :: List ) :: List ::=
+    IF isNil(l)
+    THEN Cons(x,Nil)
+    ELSE Cons(head(l),add(x,tail(l)))
+    FI
+ENDDEF
+
+CHANDEF Chans ::=
+    Input, Output :: Int
+ENDDEF
+
+PROCDEF proc [Input, Output :: Int](l :: List) ::=
+        Input ? x >-> proc [Input, Output] (add(x,l))
+    ##  [[isCons(l)]] =>> Output ! head(l) >-> proc [Input, Output] (tail(l))
+ENDDEF
+
+MODELDEF Model ::=
+    CHAN IN    Input
+    CHAN OUT   Output
+
+    BEHAVIOUR  
+        proc [Input,Output] (Nil)
+ENDDEF


### PR DESCRIPTION
The Echo model has a limitation: a new input is only accepted once the output is produced.

When inputs must be always accepted, and
1. The system either accepts an input or produces a output
2. The sequence of outputs must be equal to the sequence of inputs

One need the model as provided by EchoDelay.txs
It uses a list to buffer the accepted yet not yet echoed inputs.