### PR TITLE
enable round tripping: show procdef yields torxakis format

### DIFF
--- a/sys/core/src/TxsCore.hs
+++ b/sys/core/src/TxsCore.hs
@@ -932,8 +932,8 @@ txsShow item nm  = do
        let defs = [ (id2ident id', id2def def) | (id', def) <- Map.toList iddefs
                                               , TxsDefs.name (id2ident id') == T.pack nm' ]
        in case defs of
-            [(ident,txsdef)] -> TxsShow.fshow (ident,txsdef)
-            _                -> "no (uniquely) defined item to be shown: " ++ nm' ++ "\n"
+            [_] -> TxsShow.fshow $ TxsDefs.fromList defs
+            _   -> "no (uniquely) defined item to be shown: " ++ nm' ++ "\n"
 
 -- | Go to state with the provided state number.
 -- core action.

--- a/sys/defs/src/TxsShow.hs
+++ b/sys/defs/src/TxsShow.hs
@@ -115,7 +115,7 @@ instance PShow TxsDefs where
                                     ]
         ++ " ) "
         ++ case xt of
-             NoExit     -> "NOEXIT\n"
+             NoExit     -> "\n"
              Exit xsrts -> "EXIT " ++ Utils.join " # " (map pshow xsrts) ++ " \n"
              Hit        -> "HIT\n"
         ++ "  ::=\n" ++ pshow bexp ++  "\nENDDEF\n"


### PR DESCRIPTION
Round tripping enabled!

E.g.
load with torxakis
```
PROCDEF p [A :: Int]() ::=
    A ! 10
ENDDEF
```
type `show procdef p $> prettyPrint.txs`

you get the file `prettyPrint.txs` containing
```
PROCDEF p [ A :: Int ] ( )
::=
{ A ! 10}
>-> ( STOP
)
ENDDEF
```
And torxakis accepts the file. I.e. `torxakis prettyPrint.txs` succeeds!
