### PR TITLE
Fix wrong compiler error caused by unmatched parenthesis in function/constructor application

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ stack test --stack-yaml stack_linux.yaml --file-watch txs-compiler  --ta "-m wro
 ```
 
 Note that currently only the package `txs-compiler` supports this flag. If you
-find yourself needing this flag for other packages feel free to submit and
+find yourself needing this flag for other packages feel free to submit an
 issue or pull request.
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -101,11 +101,34 @@ by running:
 ```sh
 export MAKEFLAGS=" -j1 "
 stack setup
-stack install 
+stack install
 ```
 
 Note that the `MAKEFLAGS` variable does not affect the parallelism within
 `stack` itself.
+
+### Developing
+
+By default, several compiler warnings are treated as errors. While developing
+we'd like to avoid this: removing warnings requires some extra time. Some parts
+of the code might not make it when submitting a pull request. Therefore, before
+a new feature or fix is ready, it doesn't make sense to try to remove warnings
+on code that will be deleted in the end. So to have the build system avoid
+treating warnings as errors use the flag `develop` as follows:
+
+```sh
+stack <STACK ARGS> --flag '*:develop'
+```
+
+For instance:
+
+```sh
+stack test --stack-yaml stack_linux.yaml --file-watch txs-compiler  --ta "-m wrong" --flag '*:develop'
+```
+
+Note that currently only the package `txs-compiler` supports this flag. If you
+find yourself needing this flag for other packages feel free to submit and
+issue or pull request.
 
 ### Testing
 

--- a/sys/txs-compiler/package.yaml
+++ b/sys/txs-compiler/package.yaml
@@ -13,10 +13,19 @@ dependencies:
 - base >= 4.7 && < 5
 - lens
 
+flags:
+  develop:
+    manual: True
+    default: False
+
+when:
+- condition: (!flag(develop))
+  ghc-options:
+  - -Werror
+
 ghc-options:
-- -Werror
-- -Wall
 - -O
+- -Wall
 - -fconstraint-solver-iterations=10
 - -Wcompat
 - -Wincomplete-record-updates
@@ -28,7 +37,7 @@ library:
   exposed-modules:
   - TorXakis.Compiler
   - TorXakis.Compiler.Error
-  - TorXakis.Parser  
+  - TorXakis.Parser
   - TorXakis.Compiler.MapsTo
   dependencies:
   - text
@@ -54,11 +63,10 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    - -Werror
-    - -Wall
     - -O
     dependencies:
     - hspec
+    - hspec-core
     - filemanip
     - filepath
     - containers

--- a/sys/txs-compiler/src/TorXakis/Parser/Common.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/Common.hs
@@ -61,10 +61,53 @@ txsLangDef = LanguageDef
     , identLetter     = alphaNum <|> oneOf "_'"
     , opStart         = opLetter txsLangDef
     , opLetter        = oneOf ":!#$%&*+./<=>?@\\^|-~"
-    , reservedNames   = ["TYPEDEF", "ENDDEF", "FUNCDEF", "CONSTDEF"]
+    , reservedNames   = txsReservedNames
     , reservedOpNames = []
     , caseSensitive   = True
     }
+
+txsReservedNames :: [String]
+txsReservedNames
+  = [ "TYPEDEF"
+    , "FUNCDEF"
+    , "PROCDEF"
+    , "ENDDEF"
+    , "CHANDEF"
+    , "MODELDEF"
+    , "MAPPERDEF"
+    , "CNECTDEF"
+    , "CHAN"
+    , "ENCODE"
+    , "DECODE"
+    , "IN"
+    , "OUT"
+    , "HOST"
+    , "PORT"
+    , "CLIENTSOCK"
+    , "SERVERSOCK"
+    , "BEHAVIOUR"
+    , "IF"
+    , "THEN"
+    , "ELSE"
+    , "FI"
+    , "LET"
+    , "PURPDEF"
+    , "HIT"
+    , "MISS"
+    , "GOAL"
+    , "HIDE"
+    , "NI"
+    , "SYNC"
+    , "EXIT"
+    , "ACCEPT"
+    , "STAUTDEF"
+    , "VAR"
+    , "STATE"
+    , "INIT"
+    , "TRANS"
+    , "ISTEP"
+    , "QSTEP"
+    , "CONSTDEF" ]
 
 txsTokenP :: GenTokenParser ParserInput St Identity
 txsTokenP = makeTokenParser txsLangDef

--- a/sys/txs-compiler/src/TorXakis/Parser/ValExprDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/ValExprDecl.hs
@@ -61,10 +61,10 @@ valExpP =  buildExpressionParser table termP
 -- | Terms of the TorXakis value expressions.
 termP :: TxsParser ExpDecl
 termP = txsSymbol "(" *> ( valExpP <* txsSymbol ")")
-    <|> try (mkRegexConstExp  <$> mkLoc <*> txsRegexP)
-    <|> try letExpP
-    <|> try txsITEP
-    <|> try txsFapplP
+    <|> mkRegexConstExp  <$> mkLoc <*> txsRegexP
+    <|> letExpP
+    <|> txsITEP
+    <|> txsFapplP
     <|> mkBoolConstExp   <$> mkLoc <*> try txsBoolP
     <|> mkIntConstExp    <$> mkLoc <*> txsIntP
     <|> mkStringConstExp <$> mkLoc <*> txsStringP
@@ -73,7 +73,7 @@ termP = txsSymbol "(" *> ( valExpP <* txsSymbol ")")
 letExpP :: TxsParser ExpDecl
 letExpP = do
     l <- mkLoc
-    txsSymbol "LET"
+    try (txsSymbol "LET")
     vss <- letSeqVarDeclsP
     subEx <- inP valExpP
     return $ mkLetExpDecl vss subEx l
@@ -103,7 +103,7 @@ txsBoolP =  (txsSymbol "True" >> return True)
 
 txsRegexP :: TxsParser Text
 txsRegexP = do
-    txsSymbol "REGEX"
+    try (txsSymbol "REGEX")
     txsLexeme $ txsSymbol "('"
     res <- T.pack <$> many (satisfy regexChar)
     txsLexeme $ txsSymbol "')"
@@ -114,7 +114,7 @@ txsRegexP = do
 txsITEP :: TxsParser ExpDecl
 txsITEP = do
     l <- mkLoc
-    txsSymbol "IF"
+    try (txsSymbol "IF")
     ex0 <- valExpP
     txsSymbol "THEN"
     ex1 <- valExpP
@@ -158,5 +158,3 @@ txsFapplP = do
     exs <- valExpP `sepBy` txsSymbol ","
     txsSymbol ")"
     return $ mkFappl le lr fN exs
-
-

--- a/sys/txs-compiler/test/Common.hs
+++ b/sys/txs-compiler/test/Common.hs
@@ -1,4 +1,20 @@
--- | Common functionality for the parser and compiler tests
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  TorXakis.Common
+-- Copyright   :  (c) TNO and Radboud University
+-- License     :  BSD3 (see the file license.txt)
+--
+-- Maintainer  :  damian.nadales@gmail.com (Embedded Systems Innovation by TNO)
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Common functionality for the parser and compiler tests.
+--------------------------------------------------------------------------------
 
 module Common (txsFilesIn, checkParallel, onAllFilesIn) where
 

--- a/sys/txs-compiler/test/Common.hs
+++ b/sys/txs-compiler/test/Common.hs
@@ -20,8 +20,8 @@ module Common (txsFilesIn, checkParallel, onAllFilesIn) where
 
 import           Data.Foldable        (traverse_)
 import           System.FilePath.Find (extension, find, (==?))
-import           Test.Hspec (runIO, Spec, parallel)
-import           Test.Hspec.Core (SpecWith, SpecM)
+import           Test.Hspec (runIO, parallel)
+import           Test.Hspec.Core.Spec (SpecWith, SpecM)
 
 txsFilesIn :: FilePath -> SpecM a [FilePath]
 txsFilesIn fp =runIO $

--- a/sys/txs-compiler/test/Common.hs
+++ b/sys/txs-compiler/test/Common.hs
@@ -1,0 +1,19 @@
+-- | Common functionality for the parser and compiler tests
+
+module Common (txsFilesIn, checkParallel, onAllFilesIn) where
+
+import           Data.Foldable        (traverse_)
+import           System.FilePath.Find (extension, find, (==?))
+import           Test.Hspec (runIO, Spec, parallel)
+import           Test.Hspec.Core (SpecWith, SpecM)
+
+txsFilesIn :: FilePath -> SpecM a [FilePath]
+txsFilesIn fp =runIO $
+  find (return True) (extension ==? ".txs") fp
+
+checkParallel :: (FilePath -> SpecM a r) -> [FilePath] -> SpecWith a
+checkParallel fpTest = parallel . traverse_ fpTest
+
+onAllFilesIn :: (FilePath -> SpecM a r) -> FilePath -> SpecWith a
+onAllFilesIn test dirPath =
+  txsFilesIn dirPath >>= checkParallel test

--- a/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
@@ -25,33 +25,26 @@ import           Control.Lens            ((^?))
 import           Data.Either             (isRight)
 import           Data.Foldable           (traverse_)
 import           System.FilePath         ((</>))
-import           System.FilePath.Find    (extension, find, (==?))
 import           Test.Hspec              (Spec, describe, expectationFailure,
-                                          it, parallel, runIO, shouldBe,
+                                          it, parallel, shouldBe,
                                           shouldSatisfy)
 import           Text.RawString.QQ       (r)
 
+import           Common                  (onAllFilesIn)
 import           TorXakis.Compiler       (compileFile, compileString)
 import           TorXakis.Compiler.Error
 
 spec :: Spec
 spec = do
-    describe "Compiles the orthogonal examples" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-              ("test" </> "data" </> "success")
-        parallel $ traverse_ checkSuccess fs
-    describe "Compiles the examples in the 'examps' folder" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-              ("test" </> "data" </> "examps")
-        parallel $ traverse_ checkSuccess fs
-    describe "Compiles large models" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-                           ("test" </> "data" </> "large")
-        parallel $ traverse_ checkSuccess fs
-    describe "Compiles large models" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-                           ("test" </> "data" </> "large")
-        parallel $ traverse_ checkSuccess fs
+    describe "Compiles the files single concepts examples" $
+      checkSuccess `onAllFilesIn` ("test" </> "data" </> "success")
+
+    describe "Compiles the examples in the 'examps' folder" $
+      checkSuccess `onAllFilesIn` ("test" </> "data" </> "examps")
+
+    describe "Compiles large models" $
+      checkSuccess `onAllFilesIn` ("test" </> "data" </> "large")
+
     -- Failure test cases
     describe "Reports the expected errors " $
         parallel $ traverse_ checkFailure failureTestCases

--- a/sys/txs-compiler/test/TorXakis/ParserSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/ParserSpec.hs
@@ -19,34 +19,43 @@ module TorXakis.ParserSpec
     (spec)
 where
 
+import           Control.Lens ((^?))
 import           Data.Either          (isRight)
 import           Data.Foldable        (traverse_)
 import           System.FilePath      ((</>))
-import           System.FilePath.Find (extension, find, (==?))
-import           Test.Hspec           (Spec, describe, it, parallel, runIO,
-                                       shouldSatisfy)
+import           Test.Hspec           (Spec, describe, it, parallel,
+                                       shouldSatisfy, shouldBe)
 
-import           TorXakis.Parser      (parseFile)
+import           Common                  (onAllFilesIn)
+import           TorXakis.Compiler.Error (errorLoc, ErrorLoc(ErrorLoc))
+import           TorXakis.Parser         (parseFile)
+
 
 
 spec :: Spec
 spec = do
-    describe "Parses the orthogonal examples" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-              ("test" </> "data" </> "success")
-        parallel $ traverse_ testParser fs
+    describe "Parses the orthogonal examples" $
+      testParser `onAllFilesIn` ("test" </> "data" </> "success")
 
-    describe "Parses the examples in the 'examps' folder" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-              ("test" </> "data" </> "examps")
-        parallel $ traverse_ testParser fs
+    describe "Parses the examples in the 'examps' folder" $
+      testParser `onAllFilesIn` ("test" </> "data" </> "examps")
 
-    describe "Parses large models" $ do
-        fs <- runIO $ find (return True) (extension ==? ".txs")
-              ("test" </> "data" </> "large")
-        parallel $ traverse_ testParser fs
+    describe "Parses large models" $
+      testParser `onAllFilesIn` ("test" </> "data" </> "large")
+
+    describe "Gives the expected errors" $
+      parallel $ traverse_ checkError errors
 
     where
         testParser fp = it (show fp) $ do
             r <- parseFile fp
             r `shouldSatisfy` isRight
+
+        checkError (fp, expErr) = it (show fp) $ do
+            Left err <- parseFile fp
+            err ^? errorLoc `shouldBe` Just expErr
+
+        errors
+          = [( prefix </> "UnmatchedParenthesis.txs", ErrorLoc 15 5)]
+          where
+            prefix = "test" </> "data" </> "wrong"

--- a/sys/txs-compiler/test/data/wrong/UnmatchedParenthesis.txs
+++ b/sys/txs-compiler/test/data/wrong/UnmatchedParenthesis.txs
@@ -1,0 +1,33 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
+TYPEDEF List ::= Nil
+               | Cons{head::Int; tail::List}
+ENDDEF
+
+FUNCDEF  add (x :: Int; l :: List) :: List
+::= IF   isNil(l)
+    THEN Cons(x,Nil)
+    ELSE Cons(head(l),add(x,tail(l))
+    FI
+ENDDEF
+
+CHANDEF Chans ::=
+    Input, Output :: Int
+ENDDEF
+
+PROCDEF proc [Input, Output :: Int](l :: List) ::=
+        Input ? x >-> proc [Input, Output] (add(x,l))
+    ##  [[isCons(l)]] =>> Output ! head(l) >-> proc [Input, Output] (tail(l))
+ENDDEF
+
+MODELDEF Model ::=
+    CHAN IN    Input
+    CHAN OUT   Output
+
+    BEHAVIOUR
+        proc [Input,Output] (Nil)
+ENDDEF


### PR DESCRIPTION
- Add the `develop` flag to `txs-compiler` package, to disable errors caused by compiler warnings during development.
- Add the missing `TorXakis` keywords to the language definition.
- Factor our common functionality in tests.
- Add a test to check for this regression.

Fixes #803.