### PR TITLE
Improve support for multiple actions.

### DIFF
--- a/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
@@ -28,7 +28,7 @@ where
 
 import qualified Data.Text                   as T
 import           Text.Parsec                 (many, notFollowedBy, optionMaybe,
-                                              optional, sepBy, sepBy1, try,
+                                              sepBy, sepBy1, try, between,
                                               (<?>), (<|>))
 import           Text.Parsec.Expr            (Assoc (AssocLeft),
                                               Operator (Infix),
@@ -120,10 +120,10 @@ actOfferP = ActOfferDecl <$> offersP <*> actConstP
 
 -- | Parser for offers.
 offersP :: TxsParser [OfferDecl]
-offersP = optional (txsSymbol "{")
-           *> actOrOffer `sepBy1` pipe
-           <* optional (txsSymbol "}")
+offersP =  between (txsSymbol "{") (txsSymbol "}") actOrOffers
+       <|> actOrOffers
     where
+      actOrOffers = actOrOffer `sepBy1` pipe
       actOrOffer = predefAct <|> offerP
       pipe = try $ do
         txsSymbol "|"

--- a/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
@@ -36,7 +36,7 @@ import           TorXakis.Compiler.Error
 
 spec :: Spec
 spec = do
-    describe "Compiles the files single concepts examples" $
+    describe "Compiles the single-concept examples" $
       checkSuccess `onAllFilesIn` ("test" </> "data" </> "success")
 
     describe "Compiles the examples in the 'examps' folder" $

--- a/sys/txs-compiler/test/data/success/MultiActions.txs
+++ b/sys/txs-compiler/test/data/success/MultiActions.txs
@@ -1,0 +1,22 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
+PROCDEF p [Input :: Int] () ::=
+       ISTEP
+   >-> Input ? x
+   >-> Input ? x | ISTEP
+   >-> ISTEP | Input ? x
+   >-> STOP
+ENDDEF
+
+CHANDEF chans ::= Input :: Int ENDDEF
+
+MODELDEF M ::=
+    CHAN IN Input
+    CHAN OUT
+    BEHAVIOUR
+        p[Input]()
+ENDDEF


### PR DESCRIPTION
@pjljvandelaar and @tretmans see if you want to consider #833 closed, and open a new issue about: 

>The problem is however more sincere that a parse error:
ISTEP is the empty set of observable actions.
Observable actions happen over channels.
So ISTEP can not be a channel.

