### PR TITLE
Fix/834 stautdef parse error

### DIFF
--- a/sys/txs-compiler/package.yaml
+++ b/sys/txs-compiler/package.yaml
@@ -79,4 +79,5 @@ extra-source-files:
 - test/data/success/*.txs
 - test/data/examps/*.txs
 - test/data/parser/success/*.txs
+- test/data/regression/*.txs
 - README.md

--- a/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
@@ -151,8 +151,8 @@ predefAct =  predefOffer "ISTEP"
 --
 offerP :: TxsParser OfferDecl
 offerP = do
-    l     <- mkLoc
-    n     <- identifier
+    l <- mkLoc
+    n <- identifier
     OfferDecl (mkChanRef n l) <$> chanOffersP
 
 chanOffersP :: TxsParser [ChanOfferDecl]

--- a/sys/txs-compiler/src/TorXakis/Parser/StautDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/StautDecl.hs
@@ -49,7 +49,7 @@ stautItemP
 
       stUpdatesP :: TxsParser [StUpdate]
       stUpdatesP = txsSymbol "{" *> stUpdateP `sepBy` txsSymbol ";" <* txsSymbol "}"
-                 <|> return []
+               <|> return []
 
       stUpdateP :: TxsParser StUpdate
       stUpdateP =
@@ -59,9 +59,8 @@ stautItemP
       varRefP = flip mkVarRef <$> mkLoc <*> tryIdentifier
 
       transitionP :: TxsParser Transition
-      transitionP = try $ do
-          src <- stateRefP
-          txsSymbol "->"
+      transitionP = do
+          src <- try (stateRefP <* txsSymbol "->")
           ofrs <- actOfferP
           upds <- stUpdatesP
           txsSymbol "->"
@@ -70,6 +69,3 @@ stautItemP
 
 statesDecP :: TxsParser StateDecl
 statesDecP = mkStateDecl <$> tryIdentifier <*> mkLoc
-
-
-

--- a/sys/txs-compiler/src/TorXakis/Parser/ValExprDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/ValExprDecl.hs
@@ -126,7 +126,7 @@ txsITEP = do
 txsBopSymbolP :: TxsParser Text
 txsBopSymbolP = try $ T.pack <$> do
     op <- txsLexeme (many1 txsSpecialCOp)
-    if op `elem` [">->", "|", "||", "|||", ">>>", "[>>", "[><", "##", "<-"]
+    if op `elem` [">->", "|", "||", "|||", ">>>", "[>>", "[><", "##", "<-", "->"]
         then parserFail $ "Operator \"" ++ op
                         ++ "\" not allowed in value expressions."
         else return op

--- a/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/CompilerSpec.hs
@@ -46,6 +46,9 @@ spec = do
     describe "Compiles large models" $
       checkSuccess `onAllFilesIn` ("test" </> "data" </> "large")
 
+    describe "Compiles the regression tests" $
+      checkSuccess `onAllFilesIn` ("test" </> "data" </> "regression")
+
     -- Failure test cases
     describe "Reports the expected errors " $
         parallel $ traverse_ checkFailure failureTestCases

--- a/sys/txs-compiler/test/TorXakis/ParserSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/ParserSpec.hs
@@ -34,7 +34,7 @@ import           TorXakis.Parser         (parseFile)
 
 spec :: Spec
 spec = do
-    describe "Parses the orthogonal examples" $
+    describe "Parses the single-concept examples" $
       testParser `onAllFilesIn` ("test" </> "data" </> "success")
 
     describe "Parses the examples in the 'examps' folder" $
@@ -42,6 +42,9 @@ spec = do
 
     describe "Parses large models" $
       testParser `onAllFilesIn` ("test" </> "data" </> "large")
+
+    describe "Parses the regression tests" $
+      testParser `onAllFilesIn` ("test" </> "data" </> "regression")
 
     describe "Gives the expected errors" $
       parallel $ traverse_ checkError errors

--- a/sys/txs-compiler/test/data/regression/834-stautdef-parse-error.txs
+++ b/sys/txs-compiler/test/data/regression/834-stautdef-parse-error.txs
@@ -1,0 +1,29 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
+STAUTDEF s [Input1, Input2 :: Int; Output :: Int] () ::=
+    STATE s1,s2,s3,s4,s5
+    VAR x,y :: Int
+    INIT s1
+
+    TRANS s1 -> Input1 ? x              { x := x } -> s2
+          s2 -> Input2 ? y [[ x <> y ]] { y := y } -> s3
+          s3 -> Output ! x + y | Input1 ?x | Input2 ?y [[ x == y]] { x := x; y := y } -> s4
+          s4 -> Output ! x + y -> s5
+
+          -- TODO: find why this will break TorXakis
+          -- s4 -> Output ! x + y [[ True ]] -> s5
+ENDDEF
+
+CHANDEF chans ::= Input1,Input2, Output :: Int ENDDEF
+
+MODELDEF M ::=
+    CHAN IN Input1, Input2
+    CHAN OUT Output
+    SYNC {Input1},{Input2},{Output},{Output | Input1 | Input2}
+    BEHAVIOUR
+        s[Input1, Input2, Output]()
+ENDDEF

--- a/sys/txs-compiler/test/data/regression/834-stautdef-parse-error.txs
+++ b/sys/txs-compiler/test/data/regression/834-stautdef-parse-error.txs
@@ -13,9 +13,6 @@ STAUTDEF s [Input1, Input2 :: Int; Output :: Int] () ::=
           s2 -> Input2 ? y [[ x <> y ]] { y := y } -> s3
           s3 -> Output ! x + y | Input1 ?x | Input2 ?y [[ x == y]] { x := x; y := y } -> s4
           s4 -> Output ! x + y -> s5
-
-          -- TODO: find why this will break TorXakis
-          -- s4 -> Output ! x + y [[ True ]] -> s5
 ENDDEF
 
 CHANDEF chans ::= Input1,Input2, Output :: Int ENDDEF


### PR DESCRIPTION
This fixed the pase error reported in the first model in #834. However it does not fix the other two errors. To fix this I will need more information, in case there are related to `txs-compiler`.