### PR TITLE
compiler fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,10 +13,10 @@ version: pre-0.9.0.{build}.{branch}
 
 init:
 - ps: Write-Host Starting init at $(Get-Date)
-- ps: $env:Path += ";C:\Program Files\Git\mingw64\bin"
 - ps: $CACHE_DIR = "C:\TorXakis\.cache"
 - ps: $CACHE_DIR_REL = ".cache"
-- ps: $env:Path += ";${CACHE_DIR};${CACHE_DIR}\z3\bin;C:\Users\appveyor\AppData\Roaming\local\bin;C:\Program Files\Git\mingw64\bin"
+- ps: $env:Path += ";C:\Program Files\Git\mingw64\bin"
+- ps: $env:Path += ";${CACHE_DIR};${CACHE_DIR}\z3\bin;C:\Users\appveyor\AppData\Roaming\local\bin"
 - mkdir %LOCALAPPDATA%\Programs\stack
 - mkdir %LOCALAPPDATA%\Programs\stack\x86_64-windows
 
@@ -26,7 +26,7 @@ install:
 # obtain the stack executable
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\stack.exe")) {
-        curl -OutFile stack.zip http://www.stackage.org/stack/windows-i386 -Verbose
+        curl --location -OutFile stack.zip http://www.stackage.org/stack/windows-i386 -Verbose
         7z x $("-o" + $CACHE_DIR) stack.zip stack.exe
     } else {
         Write-Host "stack.exe found.";

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
 # obtain the stack executable
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\stack.exe")) {
-        curl --location -OutFile stack.zip http://www.stackage.org/stack/windows-i386 -Verbose
+        curl  -Verbose -OutFile stack.zip https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-windows-i386.zip
         7z x $("-o" + $CACHE_DIR) stack.zip stack.exe
     } else {
         Write-Host "stack.exe found.";

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ init:
 - ps: $env:Path += ";C:\Program Files\Git\mingw64\bin"
 - ps: $CACHE_DIR = "C:\TorXakis\.cache"
 - ps: $CACHE_DIR_REL = ".cache"
-- ps: $env:Path += ";${CACHE_DIR};${CACHE_DIR}\z3\bin;C:\Users\appveyor\AppData\Roaming\local\bin"
+- ps: $env:Path += ";${CACHE_DIR};${CACHE_DIR}\z3\bin;C:\Users\appveyor\AppData\Roaming\local\bin;C:\Program Files\Git\mingw64\bin"
 - mkdir %LOCALAPPDATA%\Programs\stack
 - mkdir %LOCALAPPDATA%\Programs\stack\x86_64-windows
 

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -15,11 +15,14 @@ then
     mkdir -p $CACHE_DIR/bin
 fi
 
-if [ -f $CACHE_DIR/bin/stack ]
+if [ -f $CACHE_DIR/bin/stack ] && [ -e $CACHE_DIR/bin/stack-1.9.3 ]
 then
     echo "$CACHE_DIR/bin/stack found in cache."
 else
-    curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C $CACHE_DIR/bin '*/stack'
+    echo "stack not found in cache or different version than 1.9.3."
+    rm -f $CACHE_DIR/bin/stack*
+    curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $CACHE_DIR/bin '*/stack'
+    touch $CACHE_DIR/bin/stack-1.9.3
 fi
 
 if [ -f $CACHE_DIR/bin/cvc4 ] && [ -e $CACHE_DIR/bin/cvc4-1.6 ]

--- a/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/BExpDecl.hs
@@ -152,8 +152,13 @@ predefAct =  predefOffer "ISTEP"
 offerP :: TxsParser OfferDecl
 offerP = do
     l <- mkLoc
-    n <- identifier
+    n <- chanName
     OfferDecl (mkChanRef n l) <$> chanOffersP
+  where
+    chanName = identifier <|> do 
+                                txsSymbol "EXIT"
+                                return $ T.pack "EXIT"
+                              
 
 chanOffersP :: TxsParser [ChanOfferDecl]
 chanOffersP = many chanOfferP

--- a/sys/txs-compiler/src/TorXakis/Parser/Common.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/Common.hs
@@ -18,7 +18,7 @@ See LICENSE at root directory of this repository.
 module TorXakis.Parser.Common
     ( TxsParser
     , txsSymbol
-    , identifier
+    , TorXakis.Parser.Common.identifier
     , mkLoc
     , lcIdentifier
     , txsLexeme
@@ -35,13 +35,14 @@ where
 
 import           Control.Monad          (void, when)
 import           Control.Monad.Identity (Identity)
+import           Data.Char              (isUpper, isLower, isAlphaNum)
 import           Data.Text              (Text)
 import qualified Data.Text              as T
-import           Text.Parsec            (ParsecT, getPosition, getState, many,
+import           Text.Parsec            (ParsecT, getPosition, getState,
                                          putState, sourceColumn, sourceLine,
                                          try, (<?>), (<|>))
-import           Text.Parsec.Char       (alphaNum, letter, lower, oneOf, upper)
-import           Text.Parsec.Token      hiding (identifier)
+import           Text.Parsec.Char       (alphaNum, letter, oneOf)
+import           Text.Parsec.Token
 
 import           TorXakis.Parser.Data
 
@@ -58,7 +59,7 @@ txsLangDef = LanguageDef
     , commentLine     = "--"
     , nestedComments  = True
     , identStart      = letter
-    , identLetter     = alphaNum <|> oneOf "_'"
+    , identLetter     = alphaNum <|> oneOf "_"
     , opStart         = opLetter txsLangDef
     , opLetter        = oneOf ":!#$%&*+./<=>?@\\^|-~"
     , reservedNames   = txsReservedNames
@@ -99,6 +100,7 @@ txsReservedNames
     , "NI"
     , "SYNC"
     , "EXIT"
+    , "STOP"
     , "ACCEPT"
     , "STAUTDEF"
     , "VAR"
@@ -111,9 +113,6 @@ txsReservedNames
 
 txsTokenP :: GenTokenParser ParserInput St Identity
 txsTokenP = makeTokenParser txsLangDef
-
-txsIdentLetter :: TxsParser Char
-txsIdentLetter = identLetter txsLangDef
 
 -- | Parse given symbol, discarding its result.
 txsSymbol :: String -- ^ String representation of the symbol.
@@ -149,33 +148,47 @@ getNextId = do
     putState $ incId st
     return (nextId st)
 
+-- | isLetter 
+isLetter :: Char -> Bool
+isLetter '_' = True
+isLetter c   = isAlphaNum c
+
 -- | Parser for upper-case identifiers.
 ucIdentifier :: String -> TxsParser Text
-ucIdentifier what = txsLexeme (identifierNE idStart) <?> what
+ucIdentifier what = (try $ do
+                               s <- Text.Parsec.Token.identifier txsTokenP
+                               if isUpperCase s 
+                                then return $ T.pack s
+                                else fail "not uppercase"
+                    ) <?> what
     where
-      idStart = upper
+      isUpperCase :: String -> Bool
+      isUpperCase s = case s of
+                            []      -> False
+                            (x:xs)  -> isUpper x && all isLetter xs
 
 -- | Parser for lower-case identifiers.
 lcIdentifier :: TxsParser Text
-lcIdentifier = txsLexeme (identifierNE idStart) <?> "lowercase identifier"
+lcIdentifier = (try $ do
+                           s <- Text.Parsec.Token.identifier txsTokenP
+                           if isLowerCase s 
+                            then return $ T.pack s
+                            else fail "not lowercase"
+                ) <?> "lowercase identifier"
     where
-      idStart = lower <|> oneOf "_"
+      isLowerCase :: String -> Bool
+      isLowerCase s = case s of
+                            []       -> False
+                            ('_':xs) -> all isLetter xs
+                            (x:xs)   -> isLower x && all isLetter xs
 
 -- | Parser for identifiers, which may start with lower or upper case letters.
 identifier :: TxsParser Text
-identifier = txsLexeme (identifierNE idStart) <?> "identifier"
-    where
-      idStart = lower <|> upper <|> oneOf "_"
+identifier = T.pack <$> Text.Parsec.Token.identifier txsTokenP <?> "identifier"
 
 -- | Like @identifier@, but try.
 tryIdentifier :: TxsParser Text
-tryIdentifier = try identifier
-
--- | Parser for non-empty identifiers.
-identifierNE :: TxsParser Char -> TxsParser Text
-identifierNE idStart = T.cons <$> idStart <*> idEnd
-    where
-      idEnd  = T.pack <$> many txsIdentLetter
+tryIdentifier = try TorXakis.Parser.Common.identifier
 
 -- | Parse expressions of the form "IN exp NI", where 'p' is the expressions
 -- parser.
@@ -217,7 +230,7 @@ declWithParamsP :: String
                 -> TxsParser a
 declWithParamsP declName paramsP bodyP end = do
     l <- try (mkLoc <* txsSymbol declName)
-    n <- txsLexeme identifier
+    n <- txsLexeme TorXakis.Parser.Common.identifier
     params <- paramsP
     txsSymbol "::="
     res <- bodyP params n l

--- a/sys/txs-compiler/src/TorXakis/Parser/Common.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/Common.hs
@@ -155,12 +155,12 @@ isLetter c   = isAlphaNum c
 
 -- | Parser for upper-case identifiers.
 ucIdentifier :: String -> TxsParser Text
-ucIdentifier what = (try $ do
+ucIdentifier what = try ( do
                                s <- Text.Parsec.Token.identifier txsTokenP
                                if isUpperCase s 
                                 then return $ T.pack s
                                 else fail "not uppercase"
-                    ) <?> what
+                        ) <?> what
     where
       isUpperCase :: String -> Bool
       isUpperCase s = case s of
@@ -169,12 +169,12 @@ ucIdentifier what = (try $ do
 
 -- | Parser for lower-case identifiers.
 lcIdentifier :: TxsParser Text
-lcIdentifier = (try $ do
+lcIdentifier = try ( do
                            s <- Text.Parsec.Token.identifier txsTokenP
                            if isLowerCase s 
                             then return $ T.pack s
                             else fail "not lowercase"
-                ) <?> "lowercase identifier"
+                   ) <?> "lowercase identifier"
     where
       isLowerCase :: String -> Bool
       isLowerCase s = case s of

--- a/sys/txs-compiler/test/TorXakis/ParserSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/ParserSpec.hs
@@ -60,7 +60,7 @@ spec = do
 
         errors
           = [( prefix </> "UnmatchedParenthesis.txs", ErrorLoc 15 5)
-            ,( prefix </> "ReservedWordAsIdentifier.txs", ErrorLoc 1 30)
+            ,( prefix </> "ReservedWordAsIdentifier.txs", ErrorLoc 7 30)
             ]
           where
             prefix = "test" </> "data" </> "wrong"

--- a/sys/txs-compiler/test/TorXakis/ParserSpec.hs
+++ b/sys/txs-compiler/test/TorXakis/ParserSpec.hs
@@ -59,6 +59,8 @@ spec = do
             err ^? errorLoc `shouldBe` Just expErr
 
         errors
-          = [( prefix </> "UnmatchedParenthesis.txs", ErrorLoc 15 5)]
+          = [( prefix </> "UnmatchedParenthesis.txs", ErrorLoc 15 5)
+            ,( prefix </> "ReservedWordAsIdentifier.txs", ErrorLoc 1 30)
+            ]
           where
             prefix = "test" </> "data" </> "wrong"

--- a/sys/txs-compiler/test/data/wrong/ReservedWordAsIdentifier.txs
+++ b/sys/txs-compiler/test/data/wrong/ReservedWordAsIdentifier.txs
@@ -1,2 +1,8 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+
 CHANDEF Chans ::= Out, ENDDEF, INIT, In   :: Int
 ENDDEF

--- a/sys/txs-compiler/test/data/wrong/ReservedWordAsIdentifier.txs
+++ b/sys/txs-compiler/test/data/wrong/ReservedWordAsIdentifier.txs
@@ -1,0 +1,2 @@
+CHANDEF Chans ::= Out, ENDDEF, INIT, In   :: Int
+ENDDEF


### PR DESCRIPTION
* Made keywords be recognized by:
   * identifier
   * lcIdentifier (lower case identifier) 
   * ucIdentifier (upper case identifier)
* removed `'` from acceptable character set of identifiers.
* added `STOP` as keyword.
* use FIXED version of stack in build environments (SemaphoreCI/AppVeyor) instead of the latest version: we want control over what we build!

fixes #865 fixes #867 fixes #866