### PR TITLE
minor changes to also compile with ghc 8.6.4

### DIFF
--- a/sys/ui/src/UI.hs
+++ b/sys/ui/src/UI.hs
@@ -339,8 +339,7 @@ cmdExit :: String -> UIO ()
 cmdExit _args  =  do
      x <- lift $ gets uihins
      case x of
-        (cmdhin:cmdhins) -> do
-                             if  cmdhin == stdin
+        (cmdhin:cmdhins) -> if  cmdhin == stdin
                                then do doCmd "QUIT" ""
                                        return ()
                                else do lift $ modify ( \e -> e { uihins = cmdhins } )

--- a/sys/ui/src/UI.hs
+++ b/sys/ui/src/UI.hs
@@ -208,43 +208,46 @@ cmdsIntprSafe = handle handleCtrlC (withInterrupt cmdsIntpr)
 -- | TorXakis UI commands processing.
 cmdsIntpr :: UIO ()
 cmdsIntpr  =  do
-     (cmdhin:_cmdhins) <- lift $ gets uihins
-     line <- if cmdhin /= stdin
-             then liftIO $ hGetLine cmdhin
-             else filter (/= '\r') . fromMaybe "" <$> getInputLine txsPrompt
-     unless (cmdhin /= stdin || null line) $
-         -- Add the line to the history, removing the duplicates, and trimming
-         -- leading and trailing white-spaces.
-         modifyHistory $ addHistoryRemovingAllDupes (strip line)
-     let (cmd,args1)   = span (/= ' ') (dropWhile (== ' ') line)
-     let (args,redir1) = span (/= '$') (dropWhile (== ' ') args1)
-     let redir         = replace "$<"  " $< "
-                         $ replace "$>"  " $> "
-                         $ replace "$>>" " $= " redir1
-     case words redir of
-           []                      -> do setOut "" WriteMode
-                                         cmdIntpr cmd args
-           ["$<",fin]              -> do setOut "" WriteMode
-                                         args' <- liftIO $ readFile fin
-                                         cmdIntpr cmd $ replace "\n" " " args'
-           ["$>",fout]             -> do setOut fout WriteMode
-                                         cmdIntpr cmd args
-           ["$=",fapp]             -> do setOut fapp AppendMode
-                                         cmdIntpr cmd args
-           ["$<",fin,"$>",fout]    -> do setOut fout WriteMode
-                                         args' <- liftIO $ readFile fin
-                                         cmdIntpr cmd $ replace "\n" " " args'
-           ["$<",fin,"$=",fapp]    -> do setOut fapp AppendMode
-                                         args' <- liftIO $ readFile fin
-                                         cmdIntpr cmd $ replace "\n" " " args'
-           ["$>",fout,"$<",fin]    -> do setOut fout WriteMode
-                                         args' <- liftIO $ readFile fin
-                                         cmdIntpr cmd $ replace "\n" " " args'
-           ["$=",fapp,"$<",fin]    -> do setOut fapp AppendMode
-                                         args' <- liftIO $ readFile fin
-                                         cmdIntpr cmd $ replace "\n" " " args'
-           _                       -> do putErr "wrong IO-redirection in command"
-                                         cmdsIntpr
+     x <- lift $ gets uihins
+     case x of
+        (cmdhin:_cmdhins) -> do
+                         line <- if cmdhin /= stdin
+                                 then liftIO $ hGetLine cmdhin
+                                 else filter (/= '\r') . fromMaybe "" <$> getInputLine txsPrompt
+                         unless (cmdhin /= stdin || null line) $
+                             -- Add the line to the history, removing the duplicates, and trimming
+                             -- leading and trailing white-spaces.
+                             modifyHistory $ addHistoryRemovingAllDupes (strip line)
+                         let (cmd,args1)   = span (/= ' ') (dropWhile (== ' ') line)
+                         let (args,redir1) = span (/= '$') (dropWhile (== ' ') args1)
+                         let redir         = replace "$<"  " $< "
+                                             $ replace "$>"  " $> "
+                                             $ replace "$>>" " $= " redir1
+                         case words redir of
+                               []                      -> do setOut "" WriteMode
+                                                             cmdIntpr cmd args
+                               ["$<",fin]              -> do setOut "" WriteMode
+                                                             args' <- liftIO $ readFile fin
+                                                             cmdIntpr cmd $ replace "\n" " " args'
+                               ["$>",fout]             -> do setOut fout WriteMode
+                                                             cmdIntpr cmd args
+                               ["$=",fapp]             -> do setOut fapp AppendMode
+                                                             cmdIntpr cmd args
+                               ["$<",fin,"$>",fout]    -> do setOut fout WriteMode
+                                                             args' <- liftIO $ readFile fin
+                                                             cmdIntpr cmd $ replace "\n" " " args'
+                               ["$<",fin,"$=",fapp]    -> do setOut fapp AppendMode
+                                                             args' <- liftIO $ readFile fin
+                                                             cmdIntpr cmd $ replace "\n" " " args'
+                               ["$>",fout,"$<",fin]    -> do setOut fout WriteMode
+                                                             args' <- liftIO $ readFile fin
+                                                             cmdIntpr cmd $ replace "\n" " " args'
+                               ["$=",fapp,"$<",fin]    -> do setOut fapp AppendMode
+                                                             args' <- liftIO $ readFile fin
+                                                             cmdIntpr cmd $ replace "\n" " " args'
+                               _                       -> do putErr "wrong IO-redirection in command"
+                                                             cmdsIntpr
+        _                    -> error "cmdsIntpr failed: error in internal structure"
 
 
 
@@ -307,11 +310,13 @@ cmdIntpr cmdname args  =
          ; "systop"        -> cmdSyStop     args
 -- ---------------------------------------------------------------------------- unrecognized --
          ; _               -> do putErr $ "unrecognized command `" ++ cmdname ++  "` (enter 'help' for help)"
-                                 (cmdhin:cmdhins) <- lift $ gets uihins
-                                 if  cmdhin == stdin
-                                    then    cmdsIntpr
-                                    else do lift $ modify ( \e -> e { uihins = cmdhins } )
-                                            cmdsIntpr
+                                 x <- lift $ gets uihins
+                                 case x of
+                                    (cmdhin:cmdhins) -> if  cmdhin == stdin
+                                                            then    cmdsIntpr
+                                                            else do lift $ modify ( \e -> e { uihins = cmdhins } )
+                                                                    cmdsIntpr
+                                    _                -> error "unrecognized command handling failed"
          }
 
 -- ----------------------------------------------------------------------------------------- --
@@ -332,12 +337,15 @@ cmdQuit _  =  do
 
 cmdExit :: String -> UIO ()
 cmdExit _args  =  do
-     (cmdhin:cmdhins) <- lift $ gets uihins
-     if  cmdhin == stdin
-       then do doCmd "QUIT" ""
-               return ()
-       else do lift $ modify ( \e -> e { uihins = cmdhins } )
-               cmdsIntpr
+     x <- lift $ gets uihins
+     case x of
+        (cmdhin:cmdhins) -> do
+                             if  cmdhin == stdin
+                               then do doCmd "QUIT" ""
+                                       return ()
+                               else do lift $ modify ( \e -> e { uihins = cmdhins } )
+                                       cmdsIntpr
+        _                -> error "cmdExit failed"
 
 -- ----------------------------------------------------------------------------------------- --
 
@@ -592,17 +600,19 @@ cmdSyStart args  =  do
              -> if Map.member nm systems
                  then do putErr "system name in use"
                          cmdsIntpr
-                 else do (Just hin, Just hout, Just herr, ph)
-                             <- liftIO $ createProcess (proc cmd args')
+                 else do x <- liftIO $ createProcess (proc cmd args')
                                                      { std_out = CreatePipe
                                                      , std_in  = CreatePipe
                                                      , std_err = CreatePipe
                                                      }
-                         liftIO $ hSetBuffering hin  NoBuffering
-                         liftIO $ hSetBuffering hout NoBuffering
-                         liftIO $ hSetBuffering herr NoBuffering
-                         lift $ modify ( \e -> e { uisystems = Map.insert nm ph systems } )
-                         cmdsIntpr
+                         case x of
+                            (Just hin, Just hout, Just herr, ph) -> do
+                                 liftIO $ hSetBuffering hin  NoBuffering
+                                 liftIO $ hSetBuffering hout NoBuffering
+                                 liftIO $ hSetBuffering herr NoBuffering
+                                 lift $ modify ( \e -> e { uisystems = Map.insert nm ph systems } )
+                                 cmdsIntpr
+                            _                                    -> error "createProcess failed"
          ; _ -> do putErr "no system to start"
                    cmdsIntpr
          }


### PR DESCRIPTION
patterns like `(a:b) <- func` need MonadFail or explicit error handling with ghc 8.6.4.
The latter were added in UI.hs