### PR TITLE
updated changes in stack, z3 and cvc4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
 # obtain the stack executable
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\stack.exe")) {
-        curl  -Verbose -OutFile stack.zip https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-windows-i386.zip
+        curl  -Verbose -OutFile stack.zip https://github.com/commercialhaskell/stack/releases/download/v2.1.1/stack-2.1.1-windows-x86_64.zip
         7z x $("-o" + $CACHE_DIR) stack.zip stack.exe
     } else {
         Write-Host "stack.exe found.";
@@ -35,7 +35,7 @@ install:
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\cvc4.exe")) {
         # obtain the cvc4 executable
-        curl -OutFile $("$CACHE_DIR\cvc4.exe") https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.6/cvc4-1.6-win64-opt.exe -Verbose
+        curl -OutFile $("$CACHE_DIR\cvc4.exe") https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.7/cvc4-1.7-win64-opt.exe -Verbose
     } else {
         Write-Host "cvc4.exe found.";
     }
@@ -43,7 +43,7 @@ install:
 - ps: |
     if (-not (Test-Path "$CACHE_DIR\z3")) {
         # install z3
-        curl -OutFile z3.zip https://github.com/TorXakis/Dependencies/releases/download/z3-4.8.5-nightly/z3-4.8.5.b63a0e31d3e2-x64-win.zip -Verbose
+        curl -OutFile z3.zip https://github.com/TorXakis/Dependencies/releases/download/z3-4.8.5/z3-4.8.5-x64-win.zip -Verbose
         mkdir $CACHE_DIR\z3
         7z x $("-o${CACHE_DIR}\z3\") z3.zip
         move ${CACHE_DIR}\z3\z3-*\* ${CACHE_DIR}\z3

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -15,40 +15,40 @@ then
     mkdir -p $CACHE_DIR/bin
 fi
 
-if [ -f $CACHE_DIR/bin/stack ] && [ -e $CACHE_DIR/bin/stack-1.9.3 ]
+if [ -f $CACHE_DIR/bin/stack ] && [ -e $CACHE_DIR/bin/stack-2.1.1 ]
 then
     echo "$CACHE_DIR/bin/stack found in cache."
 else
-    echo "stack not found in cache or different version than 1.9.3."
+    echo "stack not found in cache or different version than 2.1.1."
     rm -f $CACHE_DIR/bin/stack*
-    curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $CACHE_DIR/bin '*/stack'
-    touch $CACHE_DIR/bin/stack-1.9.3
+    curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.1/stack-2.1.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $CACHE_DIR/bin '*/stack'
+    touch $CACHE_DIR/bin/stack-2.1.1
 fi
 
-if [ -f $CACHE_DIR/bin/cvc4 ] && [ -e $CACHE_DIR/bin/cvc4-1.6 ]
+if [ -f $CACHE_DIR/bin/cvc4 ] && [ -e $CACHE_DIR/bin/cvc4-1.7 ]
 then
     echo "$CACHE_DIR/bin/cvc4 found in cache."
 else
-    echo "cvc4 not found in cache or different version than 1.6"
+    echo "cvc4 not found in cache or different version than 1.7"
     rm -f $CACHE_DIR/bin/cvc4*
-    curl -L https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.6/cvc4-1.6-x86_64-linux-opt -o cvc4
+    curl -L https://github.com/TorXakis/Dependencies/releases/download/cvc4_1.7/cvc4-1.7-x86_64-linux-opt -o cvc4
     mv cvc4 $CACHE_DIR/bin
     chmod +x $CACHE_DIR/bin/cvc4
-    touch $CACHE_DIR/bin/cvc4-1.6
+    touch $CACHE_DIR/bin/cvc4-1.7
 fi
 
-if [ -d $CACHE_DIR/z3 ] && [ -e $CACHE_DIR/z3/z3-4.8.5-nightly ]
+if [ -d $CACHE_DIR/z3 ] && [ -e $CACHE_DIR/z3/z3-4.8.5 ]
 then
-    echo "$CACHE_DIR/z3 build z3-4.8.5-nightly found in cache."
+    echo "$CACHE_DIR/z3 build z3-4.8.5found in cache."
 else
-    echo "z3 not found in cache or different version than z3-4.8.5-nightly"
+    echo "z3 not found in cache or different version than z3-4.8.5"
     rm $CACHE_DIR/z3 -rf
-    curl -L https://github.com/TorXakis/Dependencies/releases/download/z3-4.8.5-nightly/z3-4.8.5.b63a0e31d3e2-x64-ubuntu-14.04.zip -o z3.zip
+    curl -L https://github.com/TorXakis/Dependencies/releases/download/z3-4.8.5/z3-4.8.5-x64-ubuntu-14.04.zip -o z3.zip
     unzip z3.zip
     Z3NAME=$(ls -d z3-*/)
     echo $Z3NAME
     mv $Z3NAME $CACHE_DIR/z3
     chmod +x $CACHE_DIR/z3/bin/z3
-    touch $CACHE_DIR/z3/z3-4.8.5-nightly
+    touch $CACHE_DIR/z3/z3-4.8.5
 fi
 echo "Set up done"

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,24 +6,24 @@ resolver: lts-11.22
 ghc-variant: integersimple
 
 packages:
-- location: sys/behave
-- location: sys/behavedefs
-- location: sys/behaveenv
-- location: sys/bexpr
-- location: sys/cnect
-- location: sys/core
-- location: sys/coreenv
-- location: sys/defs
-- location: sys/lexregexxsd
-- location: sys/lpe
-- location: sys/server
-- location: sys/serverenv
-- location: sys/solve
-- location: sys/testsel
-- location: sys/ui
-- location: sys/value
-- location: sys/valexpr
-- location: sys/txs-compiler
+- sys/behave
+- sys/behavedefs
+- sys/behaveenv
+- sys/bexpr
+- sys/cnect
+- sys/core
+- sys/coreenv
+- sys/defs
+- sys/lexregexxsd
+- sys/lpe
+- sys/server
+- sys/serverenv
+- sys/solve
+- sys/testsel
+- sys/ui
+- sys/value
+- sys/valexpr
+- sys/txs-compiler
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -40,24 +40,24 @@ resolver: lts-11.22
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
 packages:
-- location: sys/behave
-- location: sys/behavedefs
-- location: sys/behaveenv
-- location: sys/bexpr
-- location: sys/cnect
-- location: sys/core
-- location: sys/coreenv
-- location: sys/defs
-- location: sys/lexregexxsd
-- location: sys/lpe
-- location: sys/server
-- location: sys/serverenv
-- location: sys/solve
-- location: sys/testsel
-- location: sys/ui
-- location: sys/value
-- location: sys/valexpr
-- location: sys/txs-compiler
+- sys/behave
+- sys/behavedefs
+- sys/behaveenv
+- sys/bexpr
+- sys/cnect
+- sys/core
+- sys/coreenv
+- sys/defs
+- sys/lexregexxsd
+- sys/lpe
+- sys/server
+- sys/serverenv
+- sys/solve
+- sys/testsel
+- sys/ui
+- sys/value
+- sys/valexpr
+- sys/txs-compiler
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)


### PR DESCRIPTION
All developers need to execute
`stack upgrade` to get version 2.1.1