### PR TITLE
new issues reported by HLint v2.1.26

### DIFF
--- a/sys/behave/src/Expand.hs
+++ b/sys/behave/src/Expand.hs
@@ -82,10 +82,9 @@ expand chsets (BNbexpr we (TxsDefs.view -> ActionPref (ActOffer offs hidvars cnd
                               , vid `Map.notMember` ivenv
                               ]
      tds <- gets IOB.tdefs
-     let exclams' = map toEitherTuple
-                      [ (ivar, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp) )
-                      | (ivar, vexp) <- exclams
-                      ]
+     let exclams' = [ toEitherTuple (ivar, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp) )
+                    | (ivar, vexp) <- exclams
+                    ]
      case Data.Either.partitionEithers exclams' of
        ([],r) ->    return
                       [ CTpref { ctoffers  = ctoffs
@@ -189,9 +188,9 @@ expand chsets (BNbexpr we (TxsDefs.view -> Hide chans bexp))  =
 
 expand chsets (BNbexpr we (TxsDefs.view -> ValueEnv venv bexp))  =  do
     tds   <- gets IOB.tdefs
-    let we' = map toEitherTuple [ (vid, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp))
-                                | (vid, vexp) <- Map.toList venv
-                                ]
+    let we' = [ toEitherTuple (vid, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp))
+              | (vid, vexp) <- Map.toList venv
+              ]
     case Data.Either.partitionEithers we' of
         ([],r) -> expand chsets $ BNbexpr (combineWEnv we (Map.fromList r)) bexp
         (s,_)  -> do IOB.putMsgs [ EnvData.TXS_CORE_MODEL_ERROR
@@ -206,9 +205,9 @@ expand chsets (BNbexpr we (TxsDefs.view -> StAut ini ve trns))  =  do
                                , vid `Map.notMember` ve
                                ]
     tds   <- gets IOB.tdefs
-    let vewals = map toEitherTuple [ (vid, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp) )
-                                   | (vid, vexp) <- Map.toList ve
-                                   ]
+    let vewals = [ toEitherTuple (vid, ValExpr.eval (ValExpr.subst (Map.map cstrConst we) (funcDefs tds) vexp) )
+                 | (vid, vexp) <- Map.toList ve
+                 ]
     case Data.Either.partitionEithers vewals of
         ([], r) -> concatMapM (expandTrans chsets envwals (Map.fromList r)) [ tr | tr <- trns, from tr == ini ]
         (s,_)   -> do IOB.putMsgs [ EnvData.TXS_CORE_MODEL_ERROR
@@ -230,10 +229,9 @@ expand chsets (BNbexpr we (TxsDefs.view -> StAut ini ve trns))  =  do
                        else error "ERROR: interaction and hidden variables shall be disjoint\n"
              we'   = envwals `combineWEnv` stswals
          tds <- gets IOB.tdefs
-         let exclams' = map toEitherTuple
-                          [ (ivar, ValExpr.eval (ValExpr.subst (Map.map cstrConst we') (funcDefs tds) vexp) )
-                          | (ivar, vexp) <- exclams
-                          ]
+         let exclams' = [ toEitherTuple (ivar, ValExpr.eval (ValExpr.subst (Map.map cstrConst we') (funcDefs tds) vexp) )
+                        | (ivar, vexp) <- exclams
+                        ]
          case Data.Either.partitionEithers exclams' of
             ([], r) -> do let we'' = Map.fromList [ (vid, wal)
                                                   | (vid, wal) <- Map.toList we'
@@ -346,7 +344,7 @@ expand chsets (BNenable cnode1 chanoffs cnode2)  =  do
      ctree1      <- expand chsets cnode1
      (_, quests, exclams) <- expandOffer chsets (Offer chanIdExit chanoffs)
      let ivenv = Map.fromList [ (vid, cstrVar ivar) | (vid, ivar) <- quests ]
-     let exclams' = map toEitherTuple [ (ivar, ValExpr.eval vexp) | (ivar, vexp) <- exclams ]
+     let exclams' = [ toEitherTuple (ivar, ValExpr.eval vexp) | (ivar, vexp) <- exclams ]
      case Data.Either.partitionEithers exclams' of
         ([], r) -> do let accpreds = [ cstrEqual (cstrVar ivar) (cstrConst wal) | (ivar, wal) <- r ]
                           (exits, noExits) = List.partition (\(CTpref ctoffs1 _ _ _) -> chanIdExit `Set.member` Set.map ctchan ctoffs1) ctree1

--- a/sys/core/src/Mapper.hs
+++ b/sys/core/src/Mapper.hs
@@ -64,8 +64,8 @@ mapperMap act@(TxsDDefs.Act acts)  =  do
                                                                   (cstrConst wal)
                                                       | BTree.CToffer chan choffs <- Set.toList btoffs
                                                       , (chid, wals)              <- Set.toList acts
-                                                      , (ivar, wal)               <- zip choffs wals
                                                       , chan == chid
+                                                      , (ivar, wal)               <- zip choffs wals
                                                       ]
                                                     )
                                                )

--- a/sys/lpe/src/LPE.hs
+++ b/sys/lpe/src/LPE.hs
@@ -622,7 +622,7 @@ lpePar (TxsDefs.view -> ProcInst procIdInst chansInst _paramsInst) translatedPro
           isValidStep :: Set.Set ChanId -> BExpr -> Bool
           isValidStep syncChans' (TxsDefs.view -> ActionPref ActOffer{offers=os} _) =
             let -- extract all chanIds from the offers in the ActOffer
-                chanIds = Set.foldl (\accu offer -> (chanid offer : accu)) [] os in
+                chanIds = Set.foldl (\accu offer -> chanid offer : accu) [] os in
             -- if there are no common channels with the synchronisation channels: return true
             Set.null $ Set.intersection syncChans' (Set.fromList chanIds)
           isValidStep _ _ = error "only allowed with ActionPref"
@@ -631,8 +631,8 @@ lpePar (TxsDefs.view -> ProcInst procIdInst chansInst _paramsInst) translatedPro
           isValidStepCombination :: Set.Set ChanId -> (BExpr, BExpr) -> Bool
           isValidStepCombination syncChansSet (TxsDefs.view -> ActionPref ActOffer{offers=offersL} _, TxsDefs.view -> ActionPref ActOffer{offers=offersR} _) =
             let -- extract all chanIds from the offers in the ActOffer
-                chanIdsLSet = Set.fromList $ Set.foldl (\accu offer -> (chanid offer : accu)) [] offersL
-                chanIdsRSet = Set.fromList $ Set.foldl (\accu offer -> (chanid offer : accu)) [] offersR
+                chanIdsLSet = Set.fromList $ Set.foldl (\accu offer -> chanid offer : accu) [] offersL
+                chanIdsRSet = Set.fromList $ Set.foldl (\accu offer -> chanid offer : accu) [] offersR
                 
                 intersectionLR = Set.intersection chanIdsLSet chanIdsRSet
                 intersectionLsyncChans = Set.intersection chanIdsLSet syncChansSet

--- a/sys/solve/test/TestConstraint.hs
+++ b/sys/solve/test/TestConstraint.hs
@@ -50,10 +50,9 @@ smtSolvers =  [ ("CVC4", cmdCVC4)
 
 testConstraintList :: Test
 testConstraintList =
-    TestList $ concatMap (\(l,s) -> (map (\e -> TestLabel (l ++ " " ++ fst e) $ TestCase $ do smtEnv <- createSMTEnv s False
-                                                                                              evalStateT (snd e) smtEnv )
-                                         labelTestList
-                                    )
+    TestList $ concatMap (\(l,s) -> map (\e -> TestLabel (l ++ " " ++ fst e) $ TestCase $ do smtEnv <- createSMTEnv s False
+                                                                                             evalStateT (snd e) smtEnv )
+                                        labelTestList
                          )
                          smtSolvers
 

--- a/sys/txs-compiler/src/TorXakis/Compiler/MapsTo.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/MapsTo.hs
@@ -5,7 +5,6 @@ See LICENSE at root directory of this repository.
 -}
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE ExplicitNamespaces    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ExpDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ExpDecl.hs
@@ -7,7 +7,6 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  TorXakis.Compiler.ValExpr.ExpDecl

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/SortId.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/SortId.hs
@@ -11,7 +11,6 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-missing-monadfail-instances #-}
 -- We don't want a warning for the line '[se0s, se1s, se2s] <- traverse (inferExpTypes mm) [e0, e1, e2]'

--- a/sys/txs-compiler/src/TorXakis/Parser/Data.hs
+++ b/sys/txs-compiler/src/TorXakis/Parser/Data.hs
@@ -7,7 +7,6 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeFamilies           #-}


### PR DESCRIPTION
changes include
* change `map x [.. | ..]` to `[x .. | .. ]`
* remove dependent language pragmas
* remove unneccesary brackets