### PR TITLE
Boute mod and div consistently implemented in TorXakis

### DIFF
--- a/sys/valexpr/src/Boute.hs
+++ b/sys/valexpr/src/Boute.hs
@@ -1,0 +1,67 @@
+{-
+TorXakis - Model Based Testing
+Copyright (c) 2015-2017 TNO and Radboud University
+See LICENSE at root directory of this repository.
+-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Boute Division and Modulo
+-- Copyright   :  (c) TNO and Radboud University
+-- License     :  BSD3 (see the file license.txt)
+--
+-- Maintainer  :  pierre.vandelaar@tno.nl (Embedded Systems Innovation by TNO)
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Define div and mod according to Boute's Euclidean definition, that is,
+--  so as to satisfy the formula
+--
+-- @
+--  (for all ((m Int) (n Int))
+--    (=> (distinct n 0)
+--        (let ((q (div m n)) (r (mod m n)))
+--          (and (= m (+ (* n q) r))
+--               (<= 0 r (- (abs n) 1))))))
+-- @
+--
+-- Boute, Raymond T. (April 1992). 
+--      The Euclidean definition of the functions div and mod. 
+--      ACM Transactions on Programming Languages and Systems (TOPLAS) 
+--      ACM Press. 14 (2): 127 - 144. doi:10.1145/128861.128862.
+-----------------------------------------------------------------------------
+module Boute
+( Boute.divMod
+, Boute.div
+, Boute.mod
+)
+where
+-- | operator divMod on the provided integer values.
+-- 
+-- @
+--  (for all ((m Int) (n Int))
+--    (=> (distinct n 0)
+--        (let ((q (div m n)) (r (mod m n)))
+--          (and (= m (+ (* n q) r))
+--               (<= 0 r (- (abs n) 1))))))
+-- @
+divMod :: Integer -> Integer -> (Integer, Integer)
+divMod _ 0 = error "divMod: division by zero"
+divMod m n = if n > 0 || pm == 0
+                then pdm
+                else (pd+1, pm-n)
+    where pdm@(pd, pm) = Prelude.divMod m n
+
+-- | operator divide on the provided integer values.
+div :: Integer -> Integer -> Integer
+div m = fst . Boute.divMod m
+
+-- | operator modulo on the provided integer values.
+-- 
+-- @
+--  (for all ((m Int) (n Int)) 
+--    (=> (distinct n 0)
+--               (<= 0 (mod m n) (- (abs n) 1))))
+-- @
+mod :: Integer -> Integer -> Integer
+mod m = snd . Boute.divMod m
+

--- a/sys/valexpr/src/ValExprImpls.hs
+++ b/sys/valexpr/src/ValExprImpls.hs
@@ -85,6 +85,7 @@ import qualified Data.Set           as Set
 import qualified Data.Text          as T
 import           Text.Regex.TDFA
 
+import qualified Boute
 import           Constant
 import           CstrId
 import qualified FreeMonoidX        as FMX
@@ -375,7 +376,7 @@ cstrProduct' ms =
 -- Preconditions are /not/ checked.
 cstrDivide :: ValExpr v -> ValExpr v -> ValExpr v
 cstrDivide _                          (view -> Vconst (Cint n)) | n == 0 = error "Error in model: Division by Zero in Divide"
-cstrDivide (view ->  Vconst (Cint t)) (view -> Vconst (Cint n)) = cstrConst (Cint (t `div` n) )
+cstrDivide (view ->  Vconst (Cint t)) (view -> Vconst (Cint n)) = cstrConst (Cint (t `Boute.div` n) )
 cstrDivide vet ven = ValExpr (Vdivide vet ven)
 
 -- Modulo
@@ -384,7 +385,7 @@ cstrDivide vet ven = ValExpr (Vdivide vet ven)
 -- Preconditions are /not/ checked.
 cstrModulo :: ValExpr v -> ValExpr v -> ValExpr v
 cstrModulo _                         (view -> Vconst (Cint n)) | n == 0 = error "Error in model: Division by Zero in Modulo"
-cstrModulo (view -> Vconst (Cint t)) (view -> Vconst (Cint n)) = cstrConst (Cint (t `mod` n) )
+cstrModulo (view -> Vconst (Cint t)) (view -> Vconst (Cint n)) = cstrConst (Cint (t `Boute.mod` n) )
 cstrModulo vet ven = ValExpr (Vmodulo vet ven)
 
 -- | Apply operator GEZ (Greater Equal Zero) on the provided value expression.

--- a/sys/valexpr/valexpr.cabal
+++ b/sys/valexpr/valexpr.cabal
@@ -15,7 +15,8 @@ cabal-version:          >=1.10
 library
   hs-source-dirs:       src
 
-  exposed-modules:      Constant
+  exposed-modules:      Boute
+                      , Constant
                       , CstrDef
                       , CstrId
                       , FreeMonoidX


### PR DESCRIPTION
In both smt solver and haskell code

Model in #933 is now correctly stepped:
```
TXS >>  [".\\divMod.txs"]
TXS >> stepper model
TXS >>  Stepper started
TXS >> step 10
TXS >>  .....1: Act { { ( Out, [ -102 ] ) } }
TXS >>  .....2: Act { { ( Out, [ 58 ] ) } }
TXS >>  .....3: Act { { ( Out, [ 48 ] ) } }
TXS >>  .....4: Act { { ( Out, [ -47 ] ) } }
TXS >>  .....5: Act { { ( Out, [ 18 ] ) } }
TXS >>  .....6: Act { { ( Out, [ -32 ] ) } }
TXS >>  .....7: Act { { ( Out, [ 43 ] ) } }
TXS >>  .....8: Act { { ( Out, [ -32 ] ) } }
TXS >>  .....9: Act { { ( Out, [ -17 ] ) } }
TXS >>  ....10: Act { { ( Out, [ -62 ] ) } }
TXS >>  PASS
```
fixes #933 
