### PR TITLE
Regex union

### DIFF
--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/BehExprDefs.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/BehExprDefs.hs
@@ -132,7 +132,7 @@ toBExpr mm vrvds (Pappl n l crs exs) = do
         (ls, _)             -> throwError Error
             { _errorType = NoDefinition
             , _errorLoc  = getErrorLoc l
-            , _errorMsg  = "No matching process definition found: "
+            , _errorMsg  = "No matching process definition found for '" <> toText n <> "[..](..)': "
                          <> T.pack (show ls)
             }
 toBExpr mm vrvds (Par _ sOn be0 be1) = do

--- a/sys/valexpr/src/RegexXSD2Posix.y
+++ b/sys/valexpr/src/RegexXSD2Posix.y
@@ -154,7 +154,7 @@ SingleCharEscChar   :: { Text }
                     
 RegExp  :: { Text }
         : RegExp1
-            { "^"<> $1 <> "$" }
+            { "\\`(" <> $1 <> ")\\'" }
             
 RegExp1 :: { Text }
         : Branches

--- a/sys/valexpr/test/XSD2PosixSpec.hs
+++ b/sys/valexpr/test/XSD2PosixSpec.hs
@@ -147,7 +147,7 @@ charGroupRegex list = toTestObject (foldl addCharGroupPart ("","") list)
 testTestObject :: String -> TestObject -> Test
 testTestObject s rt = TestCase $
     -- Trace.trace ( (input rt) ++ " => " ++ (expected rt) ) $ do
-    assertEqual s ("^" ++ expected rt ++ "$") (T.unpack (xsd2posix (T.pack (input rt) ) ) )
+    assertEqual s ("\\`(" ++ expected rt ++ ")\\'") (T.unpack (xsd2posix (T.pack (input rt) ) ) )
 
 ---------------------------------------------------------------------------
 -- Tests


### PR DESCRIPTION
fixes #935

With this pull request we get the desired behaviour
```
TXS >> stepper model
TXS >>  Stepper started
TXS >> step 10
TXS >>  .....1: Act { { ( Out, [ "AAAAAAAAAAAAAAAAAAA" ] ) } }
TXS >>  .....2: Act { { ( Out, [ "AA" ] ) } }
TXS >>  .....3: Act { { ( Out, [ "AAAAA" ] ) } }
TXS >>  .....4: Act { { ( Out, [ "AAAAAAAA" ] ) } }
TXS >>  .....5: Act { { ( Out, [ "" ] ) } }
TXS >>  .....6: Act { { ( Out, [ "AAAA" ] ) } }
TXS >>  .....7: Act { { ( Out, [ "AAAAAAAAAAAAAAAA" ] ) } }
TXS >>  .....8: Act { { ( Out, [ "AA" ] ) } }
TXS >>  .....9: Act { { ( Out, [ "AAA" ] ) } }
TXS >>  ....10: Act { { ( Out, [ "AAA" ] ) } }
TXS >>  PASS
```

Also improved error message a little bit by reporting name of process.