### PR TITLE
Attempt to fix merge issue permanently

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -2,13 +2,14 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-# Stack should be installed at this stage.
-
 echo $PATH
+# Stack should be installed at this stage.
 echo "stack"
 stack --version
+# CVC4 should be installed at this stage.
 echo "cvc4"
 cvc4 --version
+# Z3 should be installed at this stage.
 echo "z3"
 z3 -version
 

--- a/ci/updateAndPushGhPagesFromDevelop.sh
+++ b/ci/updateAndPushGhPagesFromDevelop.sh
@@ -2,17 +2,23 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-git remote remove origin;
-git remote add origin https://github.com/TorXakis/TorXakis.git;
-git fetch;
-git checkout gh-pages;
-git rebase develop;
-rm ./doc/* -rf
+#remove gh-pages locally
+git branch -D gh-pages
+#remove gh-pages remotely
+git push origin --delete gh-pages
+#create new gh-pages branch
+git checkout -b gh-pages;
+#generated documentation
 DOC_DIR=$(stack --work-dir .semaphore-cache/.stack-work --stack-root /home/runner/TorXakis/.semaphore-cache/.stack --allow-different-user --stack-yaml stack_linux.yaml path --local-doc-root)
 echo $DOC_DIR
 ls $DOC_DIR
+#copy documentation (ensure doc directory is empty first)
+rm ./doc/* -rf
 cp -r $DOC_DIR/. ./doc/;
+#add documentation to gh-pages branch
 git add .;
 commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)";
+#commit changes to gh-pages branch
 git commit -m "$(echo $commitMsg)";
-git push -f "https://torxakis-admin:$GITHUB_TOKEN@github.com/TorXakis/TorXakis.git";
+#push changes to gh-pages branch to remote server
+git push --set-upstream origin -f "https://torxakis-admin:$GITHUB_TOKEN@github.com/TorXakis/TorXakis.git";

--- a/ci/updateAndPushGhPagesFromDevelop.sh
+++ b/ci/updateAndPushGhPagesFromDevelop.sh
@@ -15,8 +15,6 @@ ls $DOC_DIR
 #copy documentation (ensure doc directory is empty first)
 rm ./doc/* -rf
 cp -r $DOC_DIR/. ./doc/
-#add theme for github pages
-echo "theme: jekyll-theme-slate" > _config.yml
 #add changes to gh-pages branch
 git add .
 commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)"

--- a/ci/updateAndPushGhPagesFromDevelop.sh
+++ b/ci/updateAndPushGhPagesFromDevelop.sh
@@ -15,6 +15,8 @@ ls $DOC_DIR
 #copy documentation (ensure doc directory is empty first)
 rm ./doc/* -rf
 cp -r $DOC_DIR/. ./doc/;
+#add jekyll-theme for github pages
+echo "theme: jekyll-theme-slate" > _config.yml
 #add documentation to gh-pages branch
 git add .;
 commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)";

--- a/ci/updateAndPushGhPagesFromDevelop.sh
+++ b/ci/updateAndPushGhPagesFromDevelop.sh
@@ -7,20 +7,20 @@ git branch -D gh-pages
 #remove gh-pages remotely
 git push origin --delete gh-pages
 #create new gh-pages branch
-git checkout -b gh-pages;
+git checkout -b gh-pages
 #generated documentation
 DOC_DIR=$(stack --work-dir .semaphore-cache/.stack-work --stack-root /home/runner/TorXakis/.semaphore-cache/.stack --allow-different-user --stack-yaml stack_linux.yaml path --local-doc-root)
 echo $DOC_DIR
 ls $DOC_DIR
 #copy documentation (ensure doc directory is empty first)
 rm ./doc/* -rf
-cp -r $DOC_DIR/. ./doc/;
+cp -r $DOC_DIR/. ./doc/
 #add theme for github pages
 echo "theme: jekyll-theme-slate" > _config.yml
 #add changes to gh-pages branch
-git add .;
-commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)";
+git add .
+commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)"
 #commit changes to gh-pages branch
-git commit -m "$(echo $commitMsg)";
+git commit -m "$(echo $commitMsg)"
 #push changes to gh-pages branch to remote server
-git push --set-upstream origin -f "https://torxakis-admin:$GITHUB_TOKEN@github.com/TorXakis/TorXakis.git";
+git push --set-upstream origin -f "https://torxakis-admin:$GITHUB_TOKEN@github.com/TorXakis/TorXakis.git"

--- a/ci/updateAndPushGhPagesFromDevelop.sh
+++ b/ci/updateAndPushGhPagesFromDevelop.sh
@@ -15,9 +15,9 @@ ls $DOC_DIR
 #copy documentation (ensure doc directory is empty first)
 rm ./doc/* -rf
 cp -r $DOC_DIR/. ./doc/;
-#add jekyll-theme for github pages
+#add theme for github pages
 echo "theme: jekyll-theme-slate" > _config.yml
-#add documentation to gh-pages branch
+#add changes to gh-pages branch
 git add .;
 commitMsg="Haddock @ $(date +%Y%m%d_%H%M%S)";
 #commit changes to gh-pages branch


### PR DESCRIPTION
New solution to `gh-pages`
* `gh-pages` is a temporary branch 
     * the branch is removed each time a new commit is merged to `develop`
     * a new branch is created which is equal to `develop` with added documentation.
In this way, no merge conflicts are expected (addition of documentation files should succeed).
The branch `gh-pages` thus only seems to exist permanently.