### PR TITLE
Add full evaluation of constants during expand ProcInst

### DIFF
--- a/sys/behave/behave.cabal
+++ b/sys/behave/behave.cabal
@@ -38,8 +38,9 @@ library
                       , defs
                       , solve
                       , valexpr
+                      , value
 
-                      
+
   default-language:     Haskell2010
   
 test-suite behave-test
@@ -77,5 +78,6 @@ test-suite behave-test
                      , solve
                      , txs-compiler
                      , valexpr
+                     , value
                      
   default-language:    Haskell2010

--- a/sys/behave/src/Expand.hs
+++ b/sys/behave/src/Expand.hs
@@ -52,6 +52,7 @@ import           TxsDefs
 import           TxsUtils
 import           Utils
 import           ValExpr
+import qualified Eval
 import           Variable
 import           VarId
 
@@ -163,7 +164,7 @@ expand chsets (BNbexpr we (TxsDefs.view -> ProcInst procid@(ProcId nm _ _ _ _) c
      case Map.lookup procid (procDefs tdefs) of
        Just (ProcDef chids vids bexp)
          -> do let chanmap = Map.fromList (zip chids chans)
-               let wals = map ( ValExpr.eval . ValExpr.subst (Map.map cstrConst we) (funcDefs tdefs) ) vexps
+               wals <- mapM ( Eval.eval . ValExpr.subst (Map.map cstrConst we) (funcDefs tdefs) ) vexps
                case Data.Either.partitionEithers wals of
                     ([], r) -> do let we' = Map.fromList (zip vids r)
                                   expand chsets $ BNbexpr Map.empty (relabel chanmap (Subst.subst (Map.map cstrConst we') (funcDefs tdefs) bexp) )


### PR DESCRIPTION
Not sure if this the way to handle #967 but it fixes the bug.

I guess the same eval should also be added to the other `expand` cases?