### PR TITLE
removed StAut

### DIFF
--- a/examps/Adder/AdderStAut.txs
+++ b/examps/Adder/AdderStAut.txs
@@ -39,14 +39,11 @@ STAUTDEF adder  [ Act :: Operation;  Res :: Int ] ( )
 
 ENDDEF
 
-
 CHANDEF  Chans   ::=    Action  :: Operation
                       ; Result  :: Int
 ENDDEF
 
-
 -- ----------------------------------------------------------------------------------------- --
-
 
 MODELDEF  Adder ::=
     CHAN IN    Action
@@ -54,11 +51,6 @@ MODELDEF  Adder ::=
     BEHAVIOUR  adder [ Action, Result ] ( )
 ENDDEF
 
-MODELDEF  STD_Adder ::=  -- TODO remove in final version
-    CHAN IN    Action
-    CHAN OUT   Result
-    BEHAVIOUR  stdi_adder [ Action, Result ] ( )
-ENDDEF
 -- ----------------------------------------------------------------------------------------- --
 
 CNECTDEF  SutConnection ::=

--- a/sys/behave/src/Equiv.hs
+++ b/sys/behave/src/Equiv.hs
@@ -208,12 +208,6 @@ instance Equiv BExprView
          eq_bexp <- bexp1 ~=~ bexp2
          return $ eq_ve && eq_bexp
 
-    (StAut stid1 ve1 trns1) ~=~ (StAut stid2 ve2 trns2)  =  do
-         let eq_stid = stid1 == stid2
-         let eq_ve = ve1 == ve2
-         let eq_trns = trns1 == trns2
-         return $ eq_stid && eq_ve && eq_trns
-
     _ ~=~ _  = return False
 
 -- | check elem of, with given momad equality

--- a/sys/behave/src/Reduce.hs
+++ b/sys/behave/src/Reduce.hs
@@ -249,8 +249,6 @@ reduce' (ValueEnv venv bexp) = do
     fdefs <- IOB.getFuncDefs
     reduce $ Subst.subst venv fdefs bexp
 
-reduce' (StAut stid ve trns) = return $ stAut stid ve trns
-
 -- ----------------------------------------------------------------------------------------- --
 
 instance Reduce Offer
@@ -305,7 +303,6 @@ instance FreeChan BExpr
         freeChans' (ProcInst _ chids _)    = chids
         freeChans' (Hide chids bexp)       = freeChans bexp List.\\ chids         
         freeChans' (ValueEnv _ bexp)       = freeChans bexp
-        freeChans' (StAut _ _ trns)        = concatMap freeChans trns
 
 instance FreeChan ActOffer
   where

--- a/sys/behave/src/Subst.hs
+++ b/sys/behave/src/Subst.hs
@@ -86,9 +86,6 @@ subst' ve fdefs (Hide chids bexp) =
 subst' ve fdefs (ValueEnv venv bexp) =
     subst ve fdefs (subst venv fdefs bexp)
 
-subst' ve fdefs (StAut stid venv trns) =
-    stAut stid (Map.map (subst ve fdefs) venv) trns
-
 instance Subst Offer where
     subst ve fdefs (Offer chid choffs) = Offer chid (subst ve fdefs choffs)
 

--- a/sys/behave/test/TestHelperFuncContent.hs
+++ b/sys/behave/test/TestHelperFuncContent.hs
@@ -176,7 +176,6 @@ identicalBExpr' (ProcInst pid1 chans1 vexprs1) (ProcInst pid2 chans2 vexprs2) = 
 identicalBExpr' (Hide chans1 bexpr1) (Hide chans2 bexpr2)                     =    identicalLists identicalChanId chans1 chans2
                                                                                 && identicalBExpr bexpr1 bexpr2
 identicalBExpr' (ValueEnv _mp1 _bexpr1) (ValueEnv _mp2 _bexpr2)               = error "TODO - identicalBExpr - ValueEnv"
-identicalBExpr' (StAut _sid1 _mp1 _trans1) (StAut _sid2 _mp2 _trans2)         = error "TODO - identicalBExpr - StAut"
 identicalBExpr' _ _                                                           = False
 
 newtype  FuncContent =  FuncContent { vexpr :: VExpr }

--- a/sys/defs/src/BehExprDefs.hs
+++ b/sys/defs/src/BehExprDefs.hs
@@ -44,7 +44,6 @@ module BehExprDefs
 , procInst
 , hide
 , valueEnv
-, stAut
   -- * Debugging
 , valid
 )
@@ -78,7 +77,6 @@ data BExprView = ActionPref  ActOffer BExpr
                | ProcInst    ProcId [ChanId] [VExpr]
                | Hide        [ChanId] BExpr
                | ValueEnv    VEnv BExpr
-               | StAut       StatId VEnv [Trans]
   deriving (Eq,Ord,Read,Show, Generic, NFData, Data)
 instance Resettable BExprView
     where 
@@ -94,7 +92,6 @@ instance Resettable BExprView
         reset (ProcInst p c v)  = ProcInst (reset p) (reset c) (reset v)
         reset (Hide c b)        = Hide (reset c) (reset b)
         reset (ValueEnv v b)    = ValueEnv (reset v) (reset b)
-        reset (StAut s v t)     = StAut (reset s) (reset v) (reset t)
 
 -- | BExpr: behaviour expression
 --
@@ -196,10 +193,6 @@ hide cs b = BExpr (Hide cs b)
 -- | Create a Value Environment behaviour expression.
 valueEnv :: VEnv -> BExpr -> BExpr
 valueEnv v b = BExpr (ValueEnv v b)
-
--- | Create a State Automaton behaviour expression.
-stAut :: StatId -> VEnv -> [Trans] -> BExpr
-stAut s v ts = BExpr (StAut s v ts)
 
 -- | ActOffer
 -- Offer on multiple channels with constraints

--- a/sys/defs/src/TxsShow.hs
+++ b/sys/defs/src/TxsShow.hs
@@ -204,10 +204,6 @@ instance PShow BExprView
          ++ Utils.join ";\n"
                    (map (\(k,v) -> pshow k ++ " = " ++ pshow v) (Map.assocs ve))
          ++ " IN " ++ pshow bexp ++ " NI"
-    pshow (StAut init' ve trns)
-      =  "STAUT " ++ pshow init' ++ "\n"  ++ pshow ve ++ "\n"
-           ++ Utils.join ";\n" (map pshow trns)
-
 
 -- ----------------------------------------------------------------------------------------- --
 -- PShow: ActOffer

--- a/sys/defs/src/TxsUtils.hs
+++ b/sys/defs/src/TxsUtils.hs
@@ -167,13 +167,6 @@ instance UsedFids BExprView
     usedFids (ProcInst _pid _chids vexps)   =  usedFids vexps
     usedFids (Hide _chids bexp)             =  usedFids bexp
     usedFids (ValueEnv ve bexp)             =  usedFids (Map.elems ve) ++ usedFids bexp
-    usedFids (StAut _stid ve transs)        =  usedFids (Map.elems ve) ++ usedFids transs
-
-
-instance UsedFids Trans
-  where
-    usedFids (Trans _fr actoff upd _to)  =  usedFids actoff ++ usedFids (Map.elems upd)
-
 
 instance UsedFids ActOffer
   where

--- a/sys/front/src/TxsHappy.y
+++ b/sys/front/src/TxsHappy.y
@@ -930,7 +930,7 @@ StautDef        -- :: { [(Ident,TxsDef)] }
                 --  PVDL: are global procdefs not available in the stautdef context?? 
 
               : STAUTDEF Id FormalChannels FormalVars ExitKind "::=" StautItemList EndDef
-                {  $3.inhNodeUid   = $$.inhNodeUid + 4
+                {  $3.inhNodeUid   = $$.inhNodeUid + 3
                 ;  $4.inhNodeUid   = $3.synMaxUid + 1
                 ;  $5.inhNodeUid   = $4.synMaxUid + 1
                 ;  $7.inhNodeUid   = $5.synMaxUid + 1
@@ -938,23 +938,20 @@ StautDef        -- :: { [(Ident,TxsDef)] }
                 ;  $3.inhSigs      = $$.inhSigs
                 ;  $4.inhSigs      = $$.inhSigs
                 ;  $5.inhSigs      = $$.inhSigs
-                ;  $7.inhSigs      = let (_, vars, _, _, _, _) = $7 in
+                ;  $7.inhSigs      = let (_, vars, _, _, _) = $7 in
                                         $$.inhSigs { Sigs.pro = [ ProcId $2 $$.inhNodeUid $3 $4 $5 
-                                                                , ProcId (T.pack "stdi_"<> $2) ($$.inhNodeUid + 3) $3 $4 $5
                                                                 , ProcId (T.pack "std_"<> $2) ($$.inhNodeUid + 1) $3 (combineParameters $4 (VarId (T.pack "$s") ($$.inhNodeUid + 2) sortIdInt) vars) $5
                                                                 ] }
                                                                  { Sigs.pro = [ ProcId $2 $$.inhNodeUid $3 $4 $5 ] } 
                 ;  $7.inhChanSigs  = $3
                 ;  $7.inhVarSigs   = $4
-                ;  $$.synSigs      = let (_, vars, _, _, _, _) = $7 in
+                ;  $$.synSigs      = let (_, vars, _, _, _) = $7 in
                                         Sigs.empty { Sigs.pro = [ ProcId $2 $$.inhNodeUid $3 $4 $5 
-                                                                , ProcId (T.pack "stdi_"<> $2) ($$.inhNodeUid + 3) $3 $4 $5
                                                                 , ProcId (T.pack "std_"<> $2) ($$.inhNodeUid + 1) $3 (combineParameters $4 (VarId (T.pack "$s") ($$.inhNodeUid + 2) sortIdInt) vars) $5
                                                                 ] }
-                ;  $$ = let (sts, vars, trs, init, venv, bexpr) = $7 in
+                ;  $$ = let (sts, vars, trs, init, venv) = $7 in
                         let (pd, pi) = translate (Map.empty :: Map.Map FuncId (FuncDef VarId)) ($$.inhNodeUid + 1) ($$.inhNodeUid + 2) $2 $3 $4 $5 sts vars trs init venv in
-                            [ ( IdProc (ProcId $2 $$.inhNodeUid $3 $4 $5), DefProc (ProcDef $3 $4 bexpr) )
-                            , ( IdProc (ProcId (T.pack "stdi_"<> $2) ($$.inhNodeUid + 3) $3 $4 $5), DefProc (ProcDef $3 $4 pi) )
+                            [ ( IdProc (ProcId $2 $$.inhNodeUid $3 $4 $5), DefProc (ProcDef $3 $4 pi) )
                             , ( IdProc (ProcId (T.pack "std_"<> $2) ($$.inhNodeUid + 1) $3 (combineParameters $4 (VarId (T.pack "$s") ($$.inhNodeUid + 2) sortIdInt) vars) $5), DefProc pd)
                             ]
                 ;  where if $7.synExitSorts == $5 then () else
@@ -3373,7 +3370,7 @@ NeSmallIdList   -- :: { [String] }
 -- state automaton (symbolic transition system) items
 
 
-StautItemList   -- :: { (sts,vars,trs, init, venv, BExpr) }
+StautItemList   -- :: { (sts,vars,trs, init, venv) }
                 -- top-level state automaton behaviour expression;
                 -- attrs inh : inhNodeUid  : unique node identification
                 --           : inhSortSigs : usable sorts        = global sorts
@@ -3401,7 +3398,7 @@ StautItemList   -- :: { (sts,vars,trs, init, venv, BExpr) }
                 ;  $$.synExitSorts = $1.synExitSorts
                 ;  $$ = case $1 of
                         { ( sts, vars, trs, [init], [venv] )
-                            -> (sts, vars, trs, init, venv, stAut init venv trs)
+                            -> (sts, vars, trs, init, venv)
                         ; _ -> error $ "\nTXS1010: " ++ "error in state atomaton def: " ++
                                        (show (Sigs.pro $$.inhSigs)) ++ "\n"
                         }

--- a/sys/server/src/TxsServer.hs
+++ b/sys/server/src/TxsServer.hs
@@ -184,8 +184,6 @@ cmdsIntpr = do
        "MAP"       |       IOS.isSimuled  modus  ->  cmdMap       args
        "MAP"       |       IOS.isStepped  modus  ->  cmdNoop      cmd
        "MAP"       | not $ IOS.isGtInited modus  ->  cmdNoop      cmd
-       "NCOMP"     |       IOS.isInited   modus  ->  cmdNComp     args
-       "NCOMP"     | not $ IOS.isInited   modus  ->  cmdNoop      cmd
        "LPE"       |       IOS.isInited   modus  ->  cmdLPE       args
        "LPE"       | not $ IOS.isInited   modus  ->  cmdNoop      cmd
        _           ->  cmdUnknown   cmd
@@ -945,31 +943,6 @@ cmdMap args = do
                else do act' <- lift $ TxsCore.txsMapper act
                        IFS.pack "MAP" [TxsShow.fshow act']
                        cmdsIntpr
-
--- ----------------------------------------------------------------------------------------- --
-
-cmdNComp :: String -> IOS.IOS ()
-cmdNComp args = do
-     tdefs <- lift TxsCore.txsGetTDefs
-     case words args of
-       [mname] -> case [ mdef
-                       | (TxsDefs.ModelId nm _, mdef) <- Map.toList (TxsDefs.modelDefs tdefs)
-                       , T.unpack nm == mname
-                       ] of
-                    [mdef]
-                      -> do mayPurpId <- lift $ TxsCore.txsNComp mdef
-                            case mayPurpId of
-                              Just purpid
-                                -> do IFS.pack "NCOMP" [ "Test Purpose generated: "
-                                                          ++ TxsShow.fshow purpid ]
-                                      cmdsIntpr
-                              Nothing
-                                -> do IFS.nack "NCOMP" [ "Could not generate test purpose" ]
-                                      cmdsIntpr
-                    _ -> do IFS.nack "NCOMP" [ "No such MODELDEF" ]
-                            cmdsIntpr
-       _       -> do IFS.nack "NCOMP" [ "Argument must be one MODELDEF name" ]
-                     cmdsIntpr
 
 -- ----------------------------------------------------------------------------------------- --
 

--- a/sys/ui/src/UI.hs
+++ b/sys/ui/src/UI.hs
@@ -300,7 +300,6 @@ cmdIntpr cmdname args  =
          ; "trace"         -> cmdTrace      args
          ; "menu"          -> cmdMenu       args
          ; "map"           -> cmdMap        args
-         ; "ncomp"         -> cmdNComp      args
          ; "lpe"           -> cmdLPE        args
 -- ---------------------------------------------------------------------------------- system --
          ; "systart"       -> cmdSyStart    args
@@ -566,13 +565,6 @@ cmdMenu args  =  do
 cmdMap :: String -> UIO ()
 cmdMap args  =  do
      doCmd "MAP" args
-     cmdsIntpr
-
--- ----------------------------------------------------------------------------------------- --
-
-cmdNComp :: String -> UIO ()
-cmdNComp args  =  do
-     doCmd "NCOMP" args
      cmdsIntpr
 
 -- ----------------------------------------------------------------------------------------- --


### PR DESCRIPTION
Do we want to remove the internal representation for StAut? Hence, only use process definitions.
We will loose NComp (test purpose for N complete coverage) from Petra van den Bos since it only works for StAut.
