### PR TITLE
Updates Haskell LTS version to 18.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ stack setup --stack-yaml stack_linux.yaml
 stack install --stack-yaml stack_linux.yaml
 ```
 
-```stack install``` makes the resulting executable availiable globaly. For developing purposes, ```stack build``` can be used instead. The resulting executable can then be accessed using ```stack exec torxakis -- <torxakis_options> ```.
+```stack install``` makes the resulting executable available globaly. For developing purposes, ```stack build``` can be used instead. The resulting executable can then be accessed using ```stack exec torxakis -- <torxakis_options> ```.
 
 The reason for having two configuration files is that on Windows systems the
 libraries are linked statically, and thus we cannot use the `integer-gmp`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ stack setup --stack-yaml stack_linux.yaml
 stack install --stack-yaml stack_linux.yaml
 ```
 
+```stack install``` makes the resulting executable availiable globaly. For developing purposes, ```stack build``` can be used instead. The resulting executable can then be accessed using ```stack exec torxakis -- <torxakis_options> ```.
+
 The reason for having two configuration files is that on Windows systems the
 libraries are linked statically, and thus we cannot use the `integer-gmp`
 library, since `TorXakis` is licensed under the [BSD3 license](LICENSE).

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,21 +34,20 @@ extra-deps:
 - git: https://github.com/gijsvcuyck/text-via-sockets.git
   commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
 - MissingH-1.5.0.1
+# Temporary import of deprecated package used by new compiler.
+# Can be removed if txs-compiler module is phased out again for happy based compiler.
+- Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
 
 # Override default flag values for local packages and extra-deps
 flags:
   hexpat:
     bundle: true
-  text:
-    integer-simple: true
   hashable:
     integer-gmp: false
   integer-logarithms:
     integer-gmp: false
   scientific:
     integer-simple: true
-  # text:
-  #   integer-simple: true
 
 # Extra package databases containing global packages
 extra-package-dbs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,7 +32,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - git: https://github.com/gijsvcuyck/text-via-sockets.git
-  commit: 4ce4ecef00e53891f2005bc9f0d887cbb8e914c0
+  commit: d551ccecfe81c8f970e898e2a063d6d3fd32e359
 - MissingH-1.5.0.1
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,7 +32,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - git: https://github.com/gijsvcuyck/text-via-sockets.git
-  commit: d551ccecfe81c8f970e898e2a063d6d3fd32e359
+  commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
 - MissingH-1.5.0.1
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2015-2017 TNO and Radboud University
 # See LICENSE at root directory of this repository.
 
-resolver: lts-11.22
+resolver: lts-18.28
 ghc-variant: integersimple
 
 packages:
@@ -31,8 +31,9 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- git: https://github.com/TorXakis/text-via-sockets.git
-  commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+- git: https://github.com/gijsvcuyck/text-via-sockets.git
+  commit: 4ce4ecef00e53891f2005bc9f0d887cbb8e914c0
+- MissingH-1.5.0.1
 
 # Override default flag values for local packages and extra-deps
 flags:
@@ -46,6 +47,8 @@ flags:
     integer-gmp: false
   scientific:
     integer-simple: true
+  # text:
+  #   integer-simple: true
 
 # Extra package databases containing global packages
 extra-package-dbs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,6 @@
 # See LICENSE at root directory of this repository.
 
 resolver: lts-18.28
-ghc-variant: integersimple
 
 packages:
 - sys/behave
@@ -41,13 +40,9 @@ extra-deps:
 # Override default flag values for local packages and extra-deps
 flags:
   hexpat:
+    # Set for https://github.com/TorXakis/TorXakis/issues/796. 
+    # However, this seems like a linux oriented option so it is a bit strange to have this is the windows stack file.
     bundle: true
-  hashable:
-    integer-gmp: false
-  integer-logarithms:
-    integer-gmp: false
-  scientific:
-    integer-simple: true
 
 # Extra package databases containing global packages
 extra-package-dbs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,12 +36,17 @@ extra-deps:
 # Temporary import of deprecated package used by new compiler.
 # Can be removed if txs-compiler module is phased out again for happy based compiler.
 - Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
+# These manually override the versions of the hspec related dependencies used.
+# This fixes broken test paralelization, and can be removed if the LTS version is increased enough to include them by
+- hspec-2.11.12
+- hspec-core-2.11.12
+- hspec-expectations-0.8.4
+- hspec-discover-2.11.12
 
 # Override default flag values for local packages and extra-deps
 flags:
   hexpat:
-    # Set for https://github.com/TorXakis/TorXakis/issues/796. 
-    # However, this seems like a linux oriented option so it is a bit strange to have this is the windows stack file.
+    # Use bundled version of expat dependency 
     bundle: true
 
 # Extra package databases containing global packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,22 +5,15 @@
 
 packages:
 - completed:
-    cabal-file:
-      size: 2957
-      sha256: 86721de77129c198aa3f033c79c0f7aaebce16615e6e4ea73cefb3d9771e5a94
-    name: text-via-sockets
-    version: 0.1.0.0
-    git: https://github.com/TorXakis/text-via-sockets.git
+    hackage: MissingH-1.5.0.1@sha256:34bdc3ddc94a5c58d76d3c36bc7af052213c2584492cf81f7b005c03b210a985,4791
     pantry-tree:
-      size: 682
-      sha256: 5e30ecba223e12674b7b37e668af407bbdebeea117fd3a60306a42dd636056c0
-    commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+      sha256: a708a8d90e6370fb4150d6eb45cb88034660c56c7ac799c27211fa6fc253af68
+      size: 5272
   original:
-    git: https://github.com/TorXakis/text-via-sockets.git
-    commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+    hackage: MissingH-1.5.0.1
 snapshots:
 - completed:
-    size: 527836
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/22.yaml
-    sha256: 341870ac98d8a9f8f77c4adf2e9e0b22063e264a7fbeb4c85b7af5f380dac60e
-  original: lts-11.22
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -22,6 +22,13 @@ packages:
       size: 5272
   original:
     hackage: MissingH-1.5.0.1
+- completed:
+    hackage: Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
+    pantry-tree:
+      sha256: 67d44a292c49ab6cf09225c05186f1ab64b359e965017d9d389411e4c79f0803
+      size: 1366
+  original:
+    hackage: Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,17 @@
 
 packages:
 - completed:
+    commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
+    git: https://github.com/gijsvcuyck/text-via-sockets.git
+    name: text-via-sockets
+    pantry-tree:
+      sha256: 2eb38d4b899bf5c45da210b4c8cdfa752e68150e3607c3e2718c6931894ad20b
+      size: 959
+    version: 0.1.1.0
+  original:
+    commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
+    git: https://github.com/gijsvcuyck/text-via-sockets.git
+- completed:
     hackage: MissingH-1.5.0.1@sha256:34bdc3ddc94a5c58d76d3c36bc7af052213c2584492cf81f7b005c03b210a985,4791
     pantry-tree:
       sha256: a708a8d90e6370fb4150d6eb45cb88034660c56c7ac799c27211fa6fc253af68

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -29,6 +29,34 @@ packages:
       size: 1366
   original:
     hackage: Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
+- completed:
+    hackage: hspec-2.11.12@sha256:d16b4a90470b415d56a1b561a1735566b2d8529bdbc5b26a965785768cd26ca1,1766
+    pantry-tree:
+      sha256: 465ac3cc77ed2a549bec9a104e150601c4445a68f411cb85bb03e11f72123235
+      size: 584
+  original:
+    hackage: hspec-2.11.12
+- completed:
+    hackage: hspec-core-2.11.12@sha256:4856221a10a31935006fa03cd2a4f185d89810d79616b9cbb714cf2c0f5cde17,7498
+    pantry-tree:
+      sha256: eece5609a7bc0fc6f514f03f1286d9f8efc03c8260d569f595bfc19fb311ae08
+      size: 6935
+  original:
+    hackage: hspec-core-2.11.12
+- completed:
+    hackage: hspec-expectations-0.8.4@sha256:4237f094a7931202ff57ac6475542b0b314b50a7024550e2b6eb87cfb0d4ff93,1702
+    pantry-tree:
+      sha256: 87681840d430b84686f83f1ab8b5873b09c349775698665233443914acf9ba2b
+      size: 741
+  original:
+    hackage: hspec-expectations-0.8.4
+- completed:
+    hackage: hspec-discover-2.11.12@sha256:cb6b6048b6f0fa539176f4b8012241e4c518c9803eb7ef58097c42a68b15b1c3,2171
+    pantry-tree:
+      sha256: 987023acb858acbd765dbc2173d64479cf7a376554f8318717388020a6d27101
+      size: 829
+  original:
+    hackage: hspec-discover-2.11.12
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -60,8 +60,11 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - git: https://github.com/gijsvcuyck/text-via-sockets.git
-  commit: d551ccecfe81c8f970e898e2a063d6d3fd32e359
+  commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
 - MissingH-1.5.0.1
+# Temporary import of deprecated package used by new compiler.
+# Can be removed if txs-compiler module is phased out again for happy based compiler.
+- Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
 
 flags:
   hexpat:

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -59,8 +59,9 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- git: https://github.com/TorXakis/text-via-sockets.git
-  commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+- git: https://github.com/gijsvcuyck/text-via-sockets.git
+  commit: d551ccecfe81c8f970e898e2a063d6d3fd32e359
+- MissingH-1.5.0.1
 
 flags:
   hexpat:

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -10,16 +10,10 @@
 
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
-# to be used for project dependencies. For example:
-#
-# resolver: lts-3.5
-# resolver: nightly-2015-09-21
-# resolver: ghc-7.10.2
-# resolver: ghcjs-0.1.0_ghc-7.10.2
-# resolver:
-#  name: custom-snapshot
-#  location: "./custom-snapshot.yaml"
-resolver: lts-11.22
+# to be used for project dependencies. 
+
+# NOTE: This has to manually be kept up to date with the resolver used in the main stack.yaml file.
+resolver: lts-18.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -68,6 +68,7 @@ extra-deps:
 
 flags:
   hexpat:
+    # Set for https://github.com/TorXakis/TorXakis/issues/796.
     bundle: true
 
 # Extra package databases containing global packages

--- a/stack_linux.yaml
+++ b/stack_linux.yaml
@@ -68,7 +68,7 @@ extra-deps:
 
 flags:
   hexpat:
-    # Set for https://github.com/TorXakis/TorXakis/issues/796.
+    # Use bundled version of expat dependency 
     bundle: true
 
 # Extra package databases containing global packages

--- a/stack_linux.yaml.lock
+++ b/stack_linux.yaml.lock
@@ -5,22 +5,33 @@
 
 packages:
 - completed:
-    cabal-file:
-      size: 2956
-      sha256: 9da5461d379734adabacb3e9dbdac70a2bb4b19307155f0b9309fe2f851798f5
+    commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
+    git: https://github.com/gijsvcuyck/text-via-sockets.git
     name: text-via-sockets
-    version: 0.1.0.0
-    git: https://github.com/TorXakis/text-via-sockets.git
     pantry-tree:
-      size: 682
-      sha256: 5e30ecba223e12674b7b37e668af407bbdebeea117fd3a60306a42dd636056c0
-    commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+      sha256: 2eb38d4b899bf5c45da210b4c8cdfa752e68150e3607c3e2718c6931894ad20b
+      size: 959
+    version: 0.1.1.0
   original:
-    git: https://github.com/TorXakis/text-via-sockets.git
-    commit: e3228cd0407ec0d7991a544e154ea2def184fcae
+    commit: 8817cb4210103d92ba96aca525ddcd08e1cc96e9
+    git: https://github.com/gijsvcuyck/text-via-sockets.git
+- completed:
+    hackage: MissingH-1.5.0.1@sha256:34bdc3ddc94a5c58d76d3c36bc7af052213c2584492cf81f7b005c03b210a985,4791
+    pantry-tree:
+      sha256: a708a8d90e6370fb4150d6eb45cb88034660c56c7ac799c27211fa6fc253af68
+      size: 5272
+  original:
+    hackage: MissingH-1.5.0.1
+- completed:
+    hackage: Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
+    pantry-tree:
+      sha256: 67d44a292c49ab6cf09225c05186f1ab64b359e965017d9d389411e4c79f0803
+      size: 1366
+  original:
+    hackage: Unique-0.4.7.9@sha256:7c37e22b7bb9df935c22112e67043177461aedcebe3a958854f6c0e9ecb54083,2155
 snapshots:
 - completed:
-    size: 527836
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/22.yaml
-    sha256: 341870ac98d8a9f8f77c4adf2e9e0b22063e264a7fbeb4c85b7af5f380dac60e
-  original: lts-11.22
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28

--- a/sys/behave/behave.cabal
+++ b/sys/behave/behave.cabal
@@ -60,7 +60,10 @@ test-suite behave-test
                       , TestHelperFuncContent
                       , TestProcessBehaviour
 
-  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N -fmax-pmcheck-iterations=100000000
+                      
+
+  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N 
+  -- -fmax-pmcheck-iterations=100000000 flag is deprecated, might need to be replaced with some value n in -fmax-pmcheck-models=n , but may just removing it will also work?
   
   build-depends:       base
                      , containers

--- a/sys/behave/src/Expand.hs
+++ b/sys/behave/src/Expand.hs
@@ -32,7 +32,6 @@ import           Control.Arrow
 import           Control.Monad.Extra
 import           Control.Monad.State
 import           Data.Either
-import           Data.Monoid
 
 import qualified Data.List           as List
 import qualified Data.Map            as Map

--- a/sys/behave/test/TestHelperFuncContent.hs
+++ b/sys/behave/test/TestHelperFuncContent.hs
@@ -12,7 +12,6 @@ import qualified Data.Map          as Map
 import qualified Data.Set          as Set
 import qualified Data.String.Utils as Utils
 import qualified Data.Text         as T
-import           Data.Tuple        (fst, snd)
 
 import           ChanId
 import           Constant

--- a/sys/behavedefs/src/BTree.hs
+++ b/sys/behavedefs/src/BTree.hs
@@ -36,7 +36,6 @@ module BTree
 
 where
 
-import           Data.Monoid
 import qualified Data.Set    as Set
 import qualified Data.Text   as T
 

--- a/sys/bexpr/src/StautDef.hs
+++ b/sys/bexpr/src/StautDef.hs
@@ -12,7 +12,6 @@ where
 
 import           Control.Arrow ((&&&))
 import qualified Data.Map      as Map
-import           Data.Monoid
 import qualified Data.Set      as Set
 import qualified Data.Text     as T
 

--- a/sys/core/src/Sim.hs
+++ b/sys/core/src/Sim.hs
@@ -49,7 +49,7 @@ simN depth step = do
      [(_,parval)] <- IOC.getParams ["param_InputCompletion"]
      case (read parval, IOC.state envc) of
         { ( ParamCore.ANGELIC
-          , IOC.Simuling {..}
+          , IOC.Simuling {}
           ) -> simA depth step
 --      ;  ParamCore.DEMONIC  -> simD depth step
 --      ;  ParamCore.BUFFERED -> simB depth step

--- a/sys/core/src/TxsCore.hs
+++ b/sys/core/src/TxsCore.hs
@@ -137,7 +137,6 @@ import           Control.Monad.State
 import qualified Data.List           as List
 import qualified Data.Map            as Map
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Set            as Set
 import qualified Data.Text           as T
 import           System.IO

--- a/sys/coreenv/src/Config.hs
+++ b/sys/coreenv/src/Config.hs
@@ -24,7 +24,6 @@ module Config
 where
 
 import qualified Data.Map       as Map
-import           Data.Monoid
 import           System.Process
 
 import           ParamCore

--- a/sys/defs/src/FuncTable.hs
+++ b/sys/defs/src/FuncTable.hs
@@ -39,8 +39,6 @@ import qualified Data.Map        as Map
 import           Data.Maybe
 import           Data.Text       (Text)
 import           GHC.Generics    (Generic)
-
-import           Id (Resettable)
 import           SortId
 import           ValExpr
 

--- a/sys/lpe/lpe.cabal
+++ b/sys/lpe/lpe.cabal
@@ -52,7 +52,7 @@ test-suite lpe-test
                       , TestLPEInterrupt
                       , TranslatedProcDefs
 
-  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-n
+  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N
     -- -fmax-pmcheck-iterations=100000000 flag is deprecated, might need to be replaced with some value n in -fmax-pmcheck-models=n , but may just removing it will also work?
 
 

--- a/sys/lpe/lpe.cabal
+++ b/sys/lpe/lpe.cabal
@@ -52,7 +52,9 @@ test-suite lpe-test
                       , TestLPEInterrupt
                       , TranslatedProcDefs
 
-  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N -fmax-pmcheck-iterations=100000000
+  ghc-options:       -Wall -Werror -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-n
+    -- -fmax-pmcheck-iterations=100000000 flag is deprecated, might need to be replaced with some value n in -fmax-pmcheck-models=n , but may just removing it will also work?
+
 
   build-depends:       base
                      , containers

--- a/sys/lpeops/lpeops.cabal
+++ b/sys/lpeops/lpeops.cabal
@@ -131,7 +131,7 @@ test-suite lpeops-test
                       , TestConfCheck
                       -- , TestUGuard
 
-  ghc-options:       -Werror -Wall -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N -fmax-pmcheck-iterations=100000000
+  ghc-options:       -Werror -Wall -O2 -optc-O3 -optc-ffast-math -threaded -rtsopts -with-rtsopts=-N
 
   build-depends:       base
                      , containers

--- a/sys/lpeops/src/LPE2MCRL2.hs
+++ b/sys/lpeops/src/LPE2MCRL2.hs
@@ -343,7 +343,6 @@ valExpr2dataExpr' f (ValExpr.view -> ValExpr.Vfunc funcId paramValues) = do
 valExpr2dataExpr' f (ValExpr.view -> ValExpr.Vpredef _predefKind funcId _paramValues) = do -- TODO what is Vpredef exactly?
     tdefs <- gets txsdefs
     f (sort2defaultValue tdefs (FuncId.funcsort funcId))
-valExpr2dataExpr' _f _ = return $ MCRL2Defs.DBool False
 -- valExpr2dataExpr'
 
 -- Used exclusively to translate FreeSums and FreeProducts (FreeMonoidXs):

--- a/sys/lpeops/src/core/LPEContextIds.hs
+++ b/sys/lpeops/src/core/LPEContextIds.hs
@@ -127,7 +127,6 @@ getValExprIds = customData . visitValExpr searchVisitor
                     (view -> Vconcat _)               -> idsInSubExps
                     (view -> Vstrinre _ _)            -> idsInSubExps
                     (view -> Vpredef _ fid _)         -> Set.insert (TxsDefs.IdFunc fid) idsInSubExps
-                    _                                 -> error ("GetValExprIds.searchVisitor not defined for " ++ show expr ++ "!")
         in ValExprVisitorOutput expr 1 (ids Set.\\ stdIds)
     -- searchVisitor
 -- getValExprIds

--- a/sys/lpeops/src/core/LPEPrettyPrint.hs
+++ b/sys/lpeops/src/core/LPEPrettyPrint.hs
@@ -317,7 +317,6 @@ showValExprInContext f g = customData . visitValExpr showVisitor
                     (view -> Vconcat _)               -> List.intercalate ":" pars
                     (view -> Vstrinre _ _)            -> "strinre(" ++ head pars ++ ", " ++ pars !! 1 ++ ")"
                     (view -> Vpredef _ fid _)         -> showFuncId f fid ++ "(" ++ List.intercalate ", " pars ++ ")"
-                    _                                 -> error ("ShowValExprInContext.showVisitor not defined for " ++ show expr ++ "!")
         in ValExprVisitorOutput expr 1 str
     -- showVisitor
     

--- a/sys/lpeops/src/core/LPEValidity.hs
+++ b/sys/lpeops/src/core/LPEValidity.hs
@@ -134,9 +134,6 @@ validateValExpr location scope xpr = customData (visitValExpr getProblemsVisitor
                         -- Signatures of predefined functions must be used properly:
                         (view -> Vpredef _ fid args)      ->
                             validateSortList ("predefined function \"" ++ Text.unpack (FuncId.name fid) ++ "\" call in " ++ location) (FuncId.funcargs fid) (map SortOf.sortOf args)
-                        -- We should have found a matching pattern by now:
-                        _                                 ->
-                            error ("GetValExprProblems.getProblemsVisitor not defined for " ++ show expr ++ "!")
         in ValExprVisitorOutput expr 1 (concatMap customData subExps ++ problems)
 -- getValExprProblems
 

--- a/sys/lpeops/src/utils/Satisfiability.hs
+++ b/sys/lpeops/src/utils/Satisfiability.hs
@@ -44,7 +44,6 @@ import qualified SortId
 import qualified SortOf
 import qualified SolveDefs
 import qualified TxsDefs
-import qualified ValExpr
 import qualified Constant
 import VarId
 import ValExpr

--- a/sys/lpeops/src/utils/ValExprVisitor.hs
+++ b/sys/lpeops/src/utils/ValExprVisitor.hs
@@ -128,7 +128,6 @@ visitValExprM f expr = do
       (view -> Vpredef _kd _fid vexps) ->
           do newVExps <- Monad.mapM visitValExprM1 vexps
              f newVExps expr
-      _ -> error ("VisitValExprM not defined for " ++ show expr ++ "!")
 -- visitValExprM
 
 -- Here, we think we know better (which we do) and
@@ -175,7 +174,6 @@ defaultValExprVisitorM defaultDat subExps expr = do
                   (view -> Vconcat _)                     -> cstrConcat (map expression subExps)
                   (view -> Vstrinre _ _)                  -> cstrStrInRe (expression (head subExps)) (expression (subExps !! 1))
                   (view -> Vpredef kd fid _)              -> cstrPredef kd fid (map expression subExps)
-                  _                                       -> error ("DefaultValExprVisitorM not defined for " ++ show expr ++ "!")
     return (ValExprVisitorOutput expr' 1 defaultDat)
   where
     emptyFis :: Map.Map FuncId.FuncId (FuncDef.FuncDef VarId.VarId)

--- a/sys/lpeq/src/utils/ProcInstUpdates.hs
+++ b/sys/lpeq/src/utils/ProcInstUpdates.hs
@@ -153,7 +153,6 @@ applyMapToBExpr procInstUpdateMap currentBExpr =
           error ("ValueEnv should have been eliminated by now (\"" ++ show currentBExpr ++ "\")!")
       (TxsDefs.view -> StAut _sid _venv _transitions) ->
           error ("StAut should have been eliminated by now (\"" ++ show currentBExpr ++ "\")!")
-      _ -> error ("Behavioral expression not accounted for (\"" ++ show currentBExpr ++ "\")!")
 -- applyMapToBExpr
 
 

--- a/sys/server/server.cabal
+++ b/sys/server/server.cabal
@@ -56,6 +56,7 @@ executable txsserver
                       , txs-compiler
                       , lpeops
                       , lpeutils
+                      , text-via-sockets
 
   default-language:     Haskell2010
 

--- a/sys/server/src/CmdLineParser.hs
+++ b/sys/server/src/CmdLineParser.hs
@@ -11,11 +11,10 @@ module CmdLineParser
   )
 where
 
-import           Data.Semigroup      ((<>))
 import           Options.Applicative
 
 -- imports from `core`
-import           Network
+import           Network.Socket (PortNumber)
 
 -- | Configuration options read by the command line.
 data CmdLineConfig = CmdLineConfig

--- a/sys/server/src/ToProcdef.hs
+++ b/sys/server/src/ToProcdef.hs
@@ -20,7 +20,6 @@ module ToProcdef
 
 where
 
-import           Data.Monoid
 import qualified Data.Set          as Set
 import           Data.Text         (Text)
 import qualified Data.Text         as T

--- a/sys/server/test/CmdLineParserSpec.hs
+++ b/sys/server/test/CmdLineParserSpec.hs
@@ -9,7 +9,7 @@ module CmdLineParserSpec (spec) where
 
 import           CmdLineParser
 import           Data.Maybe
-import           Network
+import           Network.Socket (PortNumber)
 import           Options.Applicative
 import           Test.Hspec
 import           Test.QuickCheck     hiding (Failure, Success)

--- a/sys/serverenv/src/EnvServer.hs
+++ b/sys/serverenv/src/EnvServer.hs
@@ -40,7 +40,7 @@ where
 
 import           Control.Concurrent
 import           Control.Monad.State
-import           Network
+import           Network.Socket
 import           System.IO
 
 import qualified Data.Map            as Map

--- a/sys/solve/src/FreeVar.hs
+++ b/sys/solve/src/FreeVar.hs
@@ -52,7 +52,6 @@ freeVars (view -> Vat s p)                 =  List.nub $ freeVars s ++ freeVars 
 freeVars (view -> Vconcat vexps)           =  List.nub $ concatMap freeVars vexps
 freeVars (view -> Vstrinre s r)            =  List.nub $ freeVars s ++ freeVars r
 freeVars (view -> Vpredef _kd _fid vexps)  =  List.nub $ concatMap freeVars vexps
-freeVars _                                 = error "freeVars - Item not in view"
 
 
 -- ----------------------------------------------------------------------------------------- --

--- a/sys/solve/src/RandIncrementBins.hs
+++ b/sys/solve/src/RandIncrementBins.hs
@@ -27,7 +27,6 @@ import           Control.Monad.State
 import qualified Data.Char             as Char
 import qualified Data.Map              as Map
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Set              as Set
 import           Data.Text             (Text)
 import qualified Data.Text             as T

--- a/sys/solve/src/RandIncrementChoice.hs
+++ b/sys/solve/src/RandIncrementChoice.hs
@@ -27,7 +27,6 @@ import           System.Random.Shuffle
 import qualified Data.Char             as Char
 import qualified Data.Map              as Map
 
-import           Data.Monoid
 import           Data.Text             (Text)
 import qualified Data.Text             as T
 

--- a/sys/solve/src/RandTrueBins.hs
+++ b/sys/solve/src/RandTrueBins.hs
@@ -27,7 +27,6 @@ where
 import           Control.Monad.State
 import qualified Data.Char             as Char
 import qualified Data.Map              as Map
-import           Data.Monoid
 import qualified Data.Set              as Set
 import           Data.Text             (Text)
 import qualified Data.Text             as T

--- a/sys/solve/src/SMT2TXS.hs
+++ b/sys/solve/src/SMT2TXS.hs
@@ -26,7 +26,6 @@ where
 
 import           Data.Either
 import qualified Data.Map          as Map
-import           Data.Monoid
 import qualified Data.String.Utils as Utils
 import           Data.Text         (Text)
 import qualified Data.Text         as T

--- a/sys/solve/src/SMTInternal.hs
+++ b/sys/solve/src/SMTInternal.hs
@@ -25,7 +25,6 @@ import           Control.Monad.State (get, gets, lift, modify, unless)
 
 import qualified Data.List           as List
 import qualified Data.Map            as Map
-import           Data.Monoid
 import           Data.String.Utils   (endswith, replace, startswith, strip)
 import           Data.Text           (Text)
 import qualified Data.Text           as T

--- a/sys/solve/src/TXS2SMT.hs
+++ b/sys/solve/src/TXS2SMT.hs
@@ -36,7 +36,6 @@ where
 
 import qualified Data.Map      as Map
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Set      as Set
 import           Data.Text     (Text)
 import qualified Data.Text     as T

--- a/sys/testsel/src/NComp.hs
+++ b/sys/testsel/src/NComp.hs
@@ -24,7 +24,6 @@ module NComp
 where
 
 import qualified Data.List   as List
-import           Data.Monoid
 import qualified Data.Set    as Set
 import qualified Data.Text           as T
 

--- a/sys/txs-compiler/src/TorXakis/Compiler.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler.hs
@@ -43,7 +43,6 @@ import           Control.Monad.State                (evalStateT)
 import           Data.Data                          (Data)
 import           Data.Map.Strict                    (Map)
 import qualified Data.Map.Strict                    as Map
-import           Data.Semigroup                     ((<>))
 import           Data.Set                           (Set)
 import qualified Data.Set                           as Set
 import           Data.Text                          (Text)

--- a/sys/txs-compiler/src/TorXakis/Compiler/Data/ProcDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Data/ProcDecl.hs
@@ -29,7 +29,6 @@ module TorXakis.Compiler.Data.ProcDecl
 where
 
 import           Data.Map                           (Map)
-import           Data.Semigroup                     ((<>))
 import           Data.Text                          (Text)
 
 import           ChanId                             (ChanId)

--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/BehExprDefs.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/BehExprDefs.hs
@@ -33,7 +33,6 @@ import           Control.Monad.Except              (liftEither, throwError)
 import           Data.List                         (nub)
 import           Data.Map                          (Map)
 import qualified Data.Map                          as Map
-import           Data.Semigroup                    ((<>))
 import qualified Data.Set                          as Set
 import           Data.Text                         (Text)
 import qualified Data.Text                         as T

--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/FuncTable.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/FuncTable.hs
@@ -29,7 +29,6 @@ import           Data.Foldable                     (foldl')
 import           Data.List.Index                   (imapM)
 import           Data.Map                          (Map)
 import qualified Data.Map                          as Map
-import           Data.Semigroup                    ((<>))
 import           Data.Text                         (Text)
 import qualified Data.Text                         as T
 

--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/ProcDef.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/ProcDef.hs
@@ -26,7 +26,6 @@ import           Control.Monad.Except               (liftEither, throwError)
 import           Data.List                          (find)
 import           Data.Map                           (Map)
 import qualified Data.Map                           as Map
-import           Data.Semigroup                     ((<>))
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T
 

--- a/sys/txs-compiler/src/TorXakis/Compiler/Defs/TxsDefs.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Defs/TxsDefs.hs
@@ -36,7 +36,6 @@ import           Data.Map                           (Map)
 import qualified Data.Map                           as Map
 import           Data.Map.Merge.Strict              (mergeA, traverseMissing,
                                                      zipWithAMatched)
-import           Data.Semigroup                     ((<>))
 import qualified Data.Set                           as Set
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T

--- a/sys/txs-compiler/src/TorXakis/Compiler/Maps.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Maps.hs
@@ -57,8 +57,7 @@ import           Control.Monad.Except     (catchError, liftEither, throwError)
 import           Data.List                (nub, sortBy)
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
-import           Data.Maybe               (catMaybes, maybe)
-import           Data.Monoid              ((<>))
+import           Data.Maybe               (catMaybes)
 import           Data.Set                 (Set)
 import qualified Data.Set                 as Set
 import           Data.Text                (Text)

--- a/sys/txs-compiler/src/TorXakis/Compiler/Maps/DefinesAMap.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Maps/DefinesAMap.hs
@@ -39,7 +39,6 @@ import           Data.Data                        (Data)
 import           Data.Data.Lens                   (biplate)
 import           Data.Map                         (Map)
 import qualified Data.Map                         as Map
-import           Data.Semigroup                   ((<>))
 import           Data.Set                         (Set)
 import qualified Data.Set                         as Set
 import           Data.Text                        (Text)

--- a/sys/txs-compiler/src/TorXakis/Compiler/MapsTo.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/MapsTo.hs
@@ -56,10 +56,10 @@ import           Data.Either.Utils       (maybeToEither)
 import           Data.Map                (Map)
 import qualified Data.Map                as Map
 import           Data.Proxy              (Proxy (Proxy))
-import           Data.Semigroup          ((<>))
 import qualified Data.Text               as T
 import           Data.Type.Bool          (type (||))
 import           Data.Typeable           (Typeable, typeOf)
+import           Data.Kind               (Type)
 import           GHC.TypeLits            (ErrorMessage ((:<>:), ShowType, Text),
                                           TypeError)
 import           Prelude                 hiding (lookup)
@@ -108,7 +108,7 @@ values mm = Map.elems im
       im = innerMap mm
 
 -- | Compute when a type is in a tree.
-type family In (x :: *) (ys :: Tree *) :: Bool where
+type family In (x :: Type) (ys :: Tree Type) :: Bool where
     In x ('Leaf y)   = x == y
     In x ('Node l r) = In x l || In x r
 
@@ -118,7 +118,7 @@ type family y == x :: Bool where
     x == y = 'False
 
 -- | Type family that represents the contents of a map.
-type family Contents mm :: Tree *
+type family Contents mm :: Tree Type
 
 -- | Search tree for types. This type would contain the key-value pairs found
 -- in a composite map.

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ExpDecl.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ExpDecl.hs
@@ -30,7 +30,6 @@ import           Control.Monad.Error.Class    (catchError, throwError)
 import           Data.List.Unique             (repeated)
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
-import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import           GHC.Exts                     (toList)
 

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/FuncDef.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/FuncDef.hs
@@ -34,7 +34,6 @@ import           Control.Monad.Except              (liftEither)
 import           Data.Either                       (partitionEithers)
 import           Data.Map                          (Map)
 import qualified Data.Map                          as Map
-import           Data.Monoid                       (mempty, (<>))
 import           GHC.Exts                          (fromList)
 import           Prelude                           hiding (lookup)
 
@@ -70,7 +69,6 @@ funcDeclToSH fids f = do
 funcDeclsToFuncDefs :: ( MapsTo (Loc VarRefE) (Either (Loc VarDeclE) [Loc FuncDeclE]) mm
                        , MapsTo (Loc VarDeclE) VarId mm
                        , MapsTo (Loc FuncDeclE) FuncId mm
-                       , In (FuncId, FuncDefInfo) (Contents mm) ~ 'False
                        , In (Loc FuncDeclE, (Signature, Handler VarId)) (Contents mm) ~ 'False )
                     => mm
                     -> Map (Loc FuncDeclE) (Signature, Handler VarId) -- ^ Standard functions, ADT functions, and user defined functions.

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/FuncId.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/FuncId.hs
@@ -30,7 +30,6 @@ module TorXakis.Compiler.ValExpr.FuncId
 where
 
 import qualified Data.Map                         as Map
-import           Data.Semigroup                   ((<>))
 import           Data.Text                        (Text)
 
 import           CstrId                           (CstrId, cstrsort, name)

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/SortId.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/SortId.hs
@@ -54,7 +54,6 @@ import           Data.List                (intersect)
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import           Data.Maybe               (catMaybes)
-import           Data.Monoid              ((<>))
 import           Data.Text                (Text)
 import qualified Data.Text                as T
 import           Data.Traversable         (for)

--- a/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ValExpr.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/ValExpr/ValExpr.hs
@@ -27,7 +27,6 @@ import           Data.Either                         (partitionEithers)
 import           Data.Foldable                       (traverse_)
 import           Data.Map                            (Map)
 import qualified Data.Map                            as Map
-import           Data.Semigroup                      ((<>))
 import qualified Data.Set                            as Set
 import qualified Data.Text                           as T
 import           GHC.Exts                            (toList)

--- a/sys/txs-compiler/src/TorXakis/Compiler/Validation.hs
+++ b/sys/txs-compiler/src/TorXakis/Compiler/Validation.hs
@@ -22,7 +22,6 @@ where
 
 import           Control.Monad.Error.Class (throwError)
 import           Data.List.Unique          (count)
-import           Data.Semigroup            ((<>))
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
 import           Id                        (Resettable, reset)

--- a/sys/ui/src/ArgsHandling.hs
+++ b/sys/ui/src/ArgsHandling.hs
@@ -44,11 +44,11 @@ getTxsUIArgs = do
       mPort = getPortId args
     return $ Right uiArgs
     where
-      getPortId :: [String] -> Maybe PortID
+      getPortId :: [String] -> Maybe PortNumber
       getPortId []    = Nothing
       getPortId (x:_) = readMaybe x
       
-      removePort :: Maybe PortID -> [String] -> [String]
+      removePort :: Maybe PortNumber -> [String] -> [String]
       removePort Nothing xs = xs
       removePort (Just _) (_:xs) = xs
       removePort _ _ = error $  "This shouldn't happen: pattern 'Just x' "

--- a/sys/ui/src/ArgsHandling.hs
+++ b/sys/ui/src/ArgsHandling.hs
@@ -7,7 +7,7 @@ See LICENSE at root directory of this repository.
 -- | Argument handling functionality for TorXakis.
 module ArgsHandling where
 
-import           Network
+import           Network.Socket
 import           System.Environment
 import           Text.Read
 
@@ -25,7 +25,7 @@ data TxsServerAddress = TxsServerAddress
     { -- | Host name of the TorXakis server.
       hostName :: HostName
       -- | Port identifier to connect to the TorXakis server.
-    , portId   :: Maybe PortID
+    , portId   :: Maybe PortNumber
     }
 
 type Error = String
@@ -46,8 +46,8 @@ getTxsUIArgs = do
     where
       getPortId :: [String] -> Maybe PortID
       getPortId []    = Nothing
-      getPortId (x:_) = PortNumber . fromInteger <$> readMaybe x
-
+      getPortId (x:_) = readMaybe x
+      
       removePort :: Maybe PortID -> [String] -> [String]
       removePort Nothing xs = xs
       removePort (Just _) (_:xs) = xs

--- a/sys/ui/ui.cabal
+++ b/sys/ui/ui.cabal
@@ -34,4 +34,6 @@ executable torxakis
                       , filepath
                       , directory
                       , async
+                      , text-via-sockets
+                      , exceptions
   default-language:     Haskell2010

--- a/sys/valexpr/src/FreeMonoidX.hs
+++ b/sys/valexpr/src/FreeMonoidX.hs
@@ -113,7 +113,6 @@ import           Data.Foldable
 import           Data.List       hiding (partition)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Semigroup  (Semigroup, (<>))
 import           GHC.Exts
 import           GHC.Generics    (Generic)
 
@@ -162,7 +161,7 @@ instance Ord a => Semigroup (FreeMonoidX a) where
 
 instance Ord a => Monoid (FreeMonoidX a) where
     mempty = FMX []
-    mappend = (<>)
+    
 
 instance Ord a => IsList (FreeMonoidX a) where
     type Item (FreeMonoidX a) = a

--- a/sys/valexpr/src/Product.hs
+++ b/sys/valexpr/src/Product.hs
@@ -89,12 +89,11 @@ instance Applicative ProductTerm where
     pure = ProductTerm
     fa <*> a = ProductTerm $ factor fa (factor a)
 
-instance Num a => Semigroup (ProductTerm a ) where
+instance Num a => Semigroup (ProductTerm a) where
     pt0 <> pt1 = pure (*) <*> pt0 <*> pt1
 
 instance Num a => Monoid (ProductTerm a) where
     mempty = pure 1
-    mappend = (<>)
 
 instance TermWrapper ProductTerm where
     wrap = ProductTerm

--- a/sys/valexpr/src/Sum.hs
+++ b/sys/valexpr/src/Sum.hs
@@ -44,8 +44,6 @@ module Sum
 import           Control.DeepSeq
 import           Data.Data
 import           Data.Foldable   hiding (sum)
-import           Data.Monoid     hiding ((<>))
-import           Data.Semigroup  (Semigroup, (<>))
 import           FreeMonoidX     (FreeMonoidX, IntMultipliable, TermWrapper,
                                   (<.>))
 import qualified FreeMonoidX     as FMX
@@ -80,7 +78,6 @@ instance Num a => Semigroup (SumTerm a) where
 
 instance Num a => Monoid (SumTerm a) where
     mempty = SumTerm 0
-    mappend = (<>)
 
 instance TermWrapper SumTerm where
     wrap = SumTerm

--- a/sys/valexpr/src/ValExprDefs.hs
+++ b/sys/valexpr/src/ValExprDefs.hs
@@ -162,7 +162,6 @@ sortOf' (view -> Vat { })                                       = sortIdString
 sortOf' (view -> Vconcat { })                                   = sortIdString
 sortOf' (view -> Vstrinre { })                                  = sortIdBool
 sortOf' (view -> Vpredef _kd (FuncId _nm _uid _fa fs) _vexps)   = fs
-sortOf' _                                                       = error "sortOf': All items must be in view"
 
 
 

--- a/sys/valexpr/src/ValExprImpls.hs
+++ b/sys/valexpr/src/ValExprImpls.hs
@@ -77,11 +77,11 @@ module ValExprImpls
 where
 
 import           Control.Arrow   (first)
+import           Control.Exception ( assert )
 import qualified Data.Map        as Map
 import           Data.Maybe      (fromMaybe)
 import qualified Data.Set        as Set
 import qualified Data.Text       as T
-import           Debug.Trace     as Trace
 import           Text.Regex.TDFA
 
 import qualified Boute

--- a/sys/valexpr/src/ValExprImpls.hs
+++ b/sys/valexpr/src/ValExprImpls.hs
@@ -76,13 +76,12 @@ module ValExprImpls
 )
 where
 
-import           Control.Arrow      (first)
-import           Control.Exception  (assert)
-import qualified Data.Map           as Map
-import           Data.Maybe         (fromMaybe)
-import           Data.Monoid        ((<>))
-import qualified Data.Set           as Set
-import qualified Data.Text          as T
+import           Control.Arrow   (first)
+import qualified Data.Map        as Map
+import           Data.Maybe      (fromMaybe)
+import qualified Data.Set        as Set
+import qualified Data.Text       as T
+import           Debug.Trace     as Trace
 import           Text.Regex.TDFA
 
 import qualified Boute

--- a/sys/valexpr/src/VarId.hs
+++ b/sys/valexpr/src/VarId.hs
@@ -15,7 +15,6 @@ where
 
 import           Control.DeepSeq
 import           Data.Data
-import           Data.Monoid
 import qualified Data.Text       as T
 import           GHC.Generics    (Generic)
 import           Id

--- a/sys/valexpr/test/FreeMonoidXSpec.hs
+++ b/sys/valexpr/test/FreeMonoidXSpec.hs
@@ -35,8 +35,7 @@ instance Num a => Semigroup (PProduct a) where
 
 instance Num a => Monoid (PProduct a) where
     mempty = PProduct 1
-    mappend = (<>)
-
+    
 instance Fractional a => Fractional (PProduct a) where
     fromRational r = PProduct (fromRational r)
     (PProduct x) / (PProduct y) = PProduct $ x / y

--- a/sys/valexpr/test/FreeMonoidXSpec.hs
+++ b/sys/valexpr/test/FreeMonoidXSpec.hs
@@ -14,7 +14,6 @@ import           Data.AEq        (AEq, (~==))
 import           Data.Foldable
 import           Data.List
 import           Data.Proxy
-import           Data.Semigroup  (Semigroup, (<>))
 import           FreeMonoidX
 import           GHC.Exts
 import           Sum             (SumTerm (..))

--- a/test/environment/stack.yaml
+++ b/test/environment/stack.yaml
@@ -10,16 +10,10 @@
 
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
-# to be used for project dependencies. For example:
-#
-# resolver: lts-3.5
-# resolver: nightly-2015-09-21
-# resolver: ghc-7.10.2
-# resolver: ghcjs-0.1.0_ghc-7.10.2
-# resolver:
-#  name: custom-snapshot
-#  location: "./custom-snapshot.yaml"
-resolver: lts-11.22
+# to be used for project dependencies.
+
+# NOTE: This has to manually be kept up to date with the resolver used in the main stack.yaml file.
+resolver: lts-18.28
 ghc-variant: integersimple
 
 # User packages to be built.

--- a/test/environment/stack.yaml
+++ b/test/environment/stack.yaml
@@ -39,8 +39,7 @@ packages:
 # Override default flag values for local packages and extra-deps
 flags: 
   hexpat:
-    # Set for https://github.com/TorXakis/TorXakis/issues/796.
-    # However, this seems like a linux oriented option so it is a bit strange to have this is the windows stack file.
+    # Use bundled version of expat dependency 
     bundle: true
 
 # Extra package databases containing global packages

--- a/test/environment/stack.yaml
+++ b/test/environment/stack.yaml
@@ -14,8 +14,6 @@
 
 # NOTE: This has to manually be kept up to date with the resolver used in the main stack.yaml file.
 resolver: lts-18.28
-ghc-variant: integersimple
-
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #
@@ -41,9 +39,9 @@ packages:
 # Override default flag values for local packages and extra-deps
 flags: 
   hexpat:
+    # Set for https://github.com/TorXakis/TorXakis/issues/796.
+    # However, this seems like a linux oriented option so it is a bit strange to have this is the windows stack file.
     bundle: true
-  text: 
-    integer-simple: true
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/test/sqatt/README.md
+++ b/test/sqatt/README.md
@@ -3,6 +3,7 @@
 This folder contains the quality assurance tests for TorXakis.
 
 ## Integration tests
+NOTE: In the old version of torxakis, these tests where executed on the torxakis executable which is first found on the path. I.E. the globally installed version. This is changed to now prefer the version build locally using stack, and only then look at the rest of the path.
 
 To run the integration tests execute:
 

--- a/test/sqatt/README.md
+++ b/test/sqatt/README.md
@@ -3,7 +3,7 @@
 This folder contains the quality assurance tests for TorXakis.
 
 ## Integration tests
-NOTE: In the old version of torxakis, these tests where executed on the torxakis executable which is first found on the path. I.E. the globally installed version. This is changed to now prefer the version build locally using stack, and only then look at the rest of the path.
+NOTE: These tests are executed on the torxakis executable which is first found on the path. I.E. the globally installed version. 
 
 To run the integration tests execute:
 

--- a/test/sqatt/README.md
+++ b/test/sqatt/README.md
@@ -3,7 +3,7 @@
 This folder contains the quality assurance tests for TorXakis.
 
 ## Integration tests
-NOTE: These tests are executed on the torxakis executable which is first found on the path. I.E. the globally installed version. 
+NOTE: These tests are executed on the torxakis executable which is first found on the path. I.E. the globally installed version. Test execution is sequential, as parallel test execution currently leads to nondeterministic test failure.
 
 To run the integration tests execute:
 
@@ -24,6 +24,11 @@ used:
 
 ```sh
 stack test --test-arguments=--match=Stimulus
+```
+
+To run a specific test suite as defined in sqatt.cabal, run
+```sh
+stack test sqatt:TESTSUITE_NAME
 ```
 
 ### Adding new tests

--- a/test/sqatt/bench/TorXakisBench.hs
+++ b/test/sqatt/bench/TorXakisBench.hs
@@ -3,9 +3,12 @@ TorXakis - Model Based Testing
 Copyright (c) 2015-2017 TNO and Radboud University
 See LICENSE at root directory of this repository.
 -}
+{-# LANGUAGE OverloadedStrings #-}
 import           Benchmarks.All
 import           Criterion.Main
-
+import           Turtle
 main :: IO ()
-main = defaultMain allBenchmarks
+main = do 
+    cd $ ".." </> ".."
+    defaultMain allBenchmarks
 

--- a/test/sqatt/sqatt.cabal
+++ b/test/sqatt/sqatt.cabal
@@ -124,6 +124,7 @@ benchmark bench
   build-depends:       base
                      , criterion
                      , sqatt
+                     , turtle
   ghc-options:         -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -O
   default-language:    Haskell2010
 

--- a/test/sqatt/src/Benchmarks/Choice.hs
+++ b/test/sqatt/src/Benchmarks/Choice.hs
@@ -17,9 +17,9 @@ benchDir = "Choice"
 do100Choices :: TxsExample
 do100Choices = emptyExample
     { exampleName = "100 choices"
-    , txsModelFiles = [txsFilePath BenchTest benchDir "Choice"]
+    , txsModelFiles = [insqatt $ txsFilePath BenchTest benchDir "Choice"]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ForeverChoice"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ForeverChoice"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Common.hs
+++ b/test/sqatt/src/Benchmarks/Common.hs
@@ -16,4 +16,4 @@ benchCommonDir :: FilePath
 benchCommonDir = "Common"
 
 seedSetupCmdFile :: FilePath
-seedSetupCmdFile = txsCmdPath BenchTest benchCommonDir "seedSetup"
+seedSetupCmdFile = insqatt $ txsCmdPath BenchTest benchCommonDir "seedSetup"

--- a/test/sqatt/src/Benchmarks/Dynamic.hs
+++ b/test/sqatt/src/Benchmarks/Dynamic.hs
@@ -30,9 +30,9 @@ benchDir = "Dynamic"
 nonDistinguishing :: TxsExample
 nonDistinguishing = emptyExample
     { exampleName = "non distinguishing output"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "nonDistinguishing" ]
+    , txsModelFiles = [insqatt $ txsFilePath BenchTest benchDir "nonDistinguishing" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "nonDistinguishing"
+                     , insqatt $ txsCmdPath BenchTest benchDir "nonDistinguishing"
                      ]
     , expectedResult = Pass
     }
@@ -40,9 +40,9 @@ nonDistinguishing = emptyExample
 distinguishByValue :: TxsExample
 distinguishByValue = emptyExample
     { exampleName = "distinguishing output by Value"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "distinguishByValue" ]
+    , txsModelFiles = [insqatt $ txsFilePath BenchTest benchDir "distinguishByValue" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "distinguishByValue"
+                     , insqatt $ txsCmdPath BenchTest benchDir "distinguishByValue"
                      ]
     , expectedResult = Pass
     }
@@ -50,9 +50,9 @@ distinguishByValue = emptyExample
 distinguishByOrder :: TxsExample
 distinguishByOrder = emptyExample
     { exampleName = "distinguishing output by Order"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "distinguishByOrder" ]
+    , txsModelFiles = [ insqatt $ txsFilePath BenchTest benchDir "distinguishByOrder" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "distinguishByOrder"
+                     , insqatt $ txsCmdPath BenchTest benchDir "distinguishByOrder"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Enable.hs
+++ b/test/sqatt/src/Benchmarks/Enable.hs
@@ -15,8 +15,8 @@ benchDir :: FilePath
 benchDir = "Enable"
 
 modelFiles :: [FilePath]
-modelFiles = [ txsFilePath BenchTest benchDir "Enable"
-             , txsFilePath BenchTest "Sequence" "SingleActionSequence"
+modelFiles = [ insqatt $ txsFilePath BenchTest benchDir "Enable"
+             , insqatt $ txsFilePath BenchTest "Sequence" "SingleActionSequence"
              ]
 
 seqEnable :: TxsExample
@@ -24,7 +24,7 @@ seqEnable = emptyExample
     { exampleName = "sequence of enable operators, without data"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SeqEnable"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SeqEnable"
                      ]
     , expectedResult = Pass
     }
@@ -34,7 +34,7 @@ seqEnableInt = emptyExample
     { exampleName = "sequence of enable operators, with integers"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SeqEnableInt"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SeqEnableInt"
                      ]
     , expectedResult = Pass
     }
@@ -44,7 +44,7 @@ seqEnableTwoInts = emptyExample
     { exampleName = "sequence of enable operators, with integers and two outputs"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SeqEnableTwoInts"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SeqEnableTwoInts"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Hiding.hs
+++ b/test/sqatt/src/Benchmarks/Hiding.hs
@@ -15,8 +15,8 @@ benchDir :: FilePath
 benchDir = "Hiding"
 
 modelFiles :: [FilePath]
-modelFiles = [ txsFilePath BenchTest benchDir "Hiding"
-             , txsFilePath BenchTest "Sequence" "SingleActionSequence"
+modelFiles = [ insqatt $ txsFilePath BenchTest benchDir "Hiding"
+             , insqatt $ txsFilePath BenchTest "Sequence" "SingleActionSequence"
              ]
 
 alt4hide1 :: TxsExample
@@ -24,7 +24,7 @@ alt4hide1 = emptyExample
     { exampleName = "alternate 4 hide 1 action"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Alternate4Hide1Act"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Alternate4Hide1Act"
                      ]
     , expectedResult = Pass
     }
@@ -34,7 +34,7 @@ hideFirstSFA = emptyExample
     { exampleName = "hide first of sync first alternate"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "HideFirstSFA"
+                     , insqatt $ txsCmdPath BenchTest benchDir "HideFirstSFA"
                      ]
     , expectedResult = Pass
     }
@@ -44,7 +44,7 @@ hideSecondSFA = emptyExample
     { exampleName = "hide second of sync second alternate"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "HideSecondSFA"
+                     , insqatt $ txsCmdPath BenchTest benchDir "HideSecondSFA"
                      ]
     , expectedResult = Pass
     }
@@ -54,7 +54,7 @@ matchNoData = emptyExample
     { exampleName = "match"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Match"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Match"
                      ]
     , expectedResult = Pass
     }
@@ -64,7 +64,7 @@ matchInt = emptyExample
     { exampleName = "match Int"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "MatchInt"
+                     , insqatt $ txsCmdPath BenchTest benchDir "MatchInt"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Parallel.hs
+++ b/test/sqatt/src/Benchmarks/Parallel.hs
@@ -15,8 +15,8 @@ benchDir :: FilePath
 benchDir = "Parallel"
 
 modelFiles :: [FilePath]
-modelFiles = [ txsFilePath BenchTest benchDir "Parallel"
-             , txsFilePath BenchTest "Sequence" "SingleActionSequence"
+modelFiles = [ insqatt $ txsFilePath BenchTest benchDir "Parallel"
+             , insqatt $ txsFilePath BenchTest "Sequence" "SingleActionSequence"
              ]
 
 parallel4 :: TxsExample
@@ -24,7 +24,7 @@ parallel4 = emptyExample
     { exampleName = "4 parallel sequential-processes"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Parallel4"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Parallel4"
                      ]
     , expectedResult = Pass
     }
@@ -34,7 +34,7 @@ parallelIStep4 = emptyExample
     { exampleName = "4 parallel sequential-processes, with internal step"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Parallel4"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Parallel4"
                      ]
     , expectedResult = Pass
     }
@@ -45,7 +45,7 @@ parallelAlternate4 = emptyExample
     { exampleName = "4 parallel sequential-processes, with alternating actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ParallelAlternate4"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ParallelAlternate4"
                      ]
     , expectedResult = Pass
     }
@@ -55,7 +55,7 @@ parallelMultiact4 = emptyExample
     { exampleName = "4 parallel sequential-processes, with multiple actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ParallelMultiAct"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ParallelMultiAct"
                      ]
     , expectedResult = Pass
     }
@@ -65,7 +65,7 @@ parallelSync = emptyExample
     { exampleName = "convoluted parallel-synchronous model"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ParallelSync"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ParallelSync"
                      ]
     , expectedResult = Fail
     }
@@ -75,7 +75,7 @@ parallelNested = emptyExample
     { exampleName = "4 parallel nested synchronizing sequences"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ParallelNested"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ParallelNested"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/RealWorld.hs
+++ b/test/sqatt/src/Benchmarks/RealWorld.hs
@@ -17,9 +17,9 @@ benchDir = "RealWorld"
 multipleControlLoops :: TxsExample
 multipleControlLoops = emptyExample
     { exampleName = "Multiple Control Loops Stepper"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "MultipleControlLoops" ]
+    , txsModelFiles = [ insqatt $ txsFilePath BenchTest benchDir "MultipleControlLoops" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "MultipleControlLoops"
+                     , insqatt $ txsCmdPath BenchTest benchDir "MultipleControlLoops"
                      ]
     , expectedResult = Pass
     }
@@ -27,17 +27,17 @@ multipleControlLoops = emptyExample
 customersAndOrders :: TxsExample
 customersAndOrders = emptyExample
     { exampleName = "Customers and Orders"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "CustomersOrders" ]
-    , txsCmdsFiles = [ txsCmdPath BenchTest benchDir "CustomersOrders" ]
+    , txsModelFiles = [ insqatt $ txsFilePath BenchTest benchDir "CustomersOrders" ]
+    , txsCmdsFiles = [ insqatt $ txsCmdPath BenchTest benchDir "CustomersOrders" ]
     , expectedResult = Pass
     }
 
 movingArms :: TxsExample
 movingArms = emptyExample
     { exampleName = "Moving Arms"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "MovingArms" ]
+    , txsModelFiles = [ insqatt $ txsFilePath BenchTest benchDir "MovingArms" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "MovingArms"
+                     , insqatt $ txsCmdPath BenchTest benchDir "MovingArms"
                      ]
     , expectedResult = Pass
     }
@@ -45,9 +45,9 @@ movingArms = emptyExample
 movingArmsPurpose :: TxsExample
 movingArmsPurpose = emptyExample
     { exampleName = "Moving Arms (Purpose)"
-    , txsModelFiles = [ txsFilePath BenchTest benchDir "MovingArms" ]
+    , txsModelFiles = [ insqatt $ txsFilePath BenchTest benchDir "MovingArms" ]
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "MovingArmsPurpose"
+                     , insqatt $ txsCmdPath BenchTest benchDir "MovingArmsPurpose"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Sequence.hs
+++ b/test/sqatt/src/Benchmarks/Sequence.hs
@@ -15,14 +15,14 @@ benchDir :: FilePath
 benchDir = "Sequence"
 
 modelFiles :: [FilePath]
-modelFiles = [txsFilePath BenchTest benchDir "SingleActionSequence"]
+modelFiles = [insqatt $ txsFilePath BenchTest benchDir "SingleActionSequence"]
 
 do100Acts :: TxsExample
 do100Acts = emptyExample
     { exampleName = "100 actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SingleActionSequence"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SingleActionSequence"
                      ]
     , expectedResult = Pass
     }
@@ -32,7 +32,7 @@ do100IActs = emptyExample
     { exampleName = "100 internal actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SingleActionIStepSequence"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SingleActionIStepSequence"
                      ]
     , expectedResult = Pass
     }
@@ -42,7 +42,7 @@ do100DataActs = emptyExample
     { exampleName = "100 data actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ForeverOutput4"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ForeverOutput4"
                      ]
     , expectedResult = Pass
     }
@@ -52,7 +52,7 @@ sequence10Ints = emptyExample
     { exampleName = "sequence with a 10 integer channel"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Sequence10Ints"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Sequence10Ints"
                      ]
     , expectedResult = Pass
     }
@@ -62,7 +62,7 @@ sequence10IntsCvc4 = emptyExample
     { exampleName = "sequence with a 10 integer channel (cvc4)"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Sequence10Ints"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Sequence10Ints"
                      ]
     , txsServerArgs = ["--smt-solver", "cvc4"]
       , expectedResult = Pass
@@ -73,7 +73,7 @@ sequence10IntsTD = emptyExample
     { exampleName = "sequence with a 10 integer channel, using a custom type"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "Sequence10IntsTypeDef"
+                     , insqatt $ txsCmdPath BenchTest benchDir "Sequence10IntsTypeDef"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/Benchmarks/Sequence.hs
+++ b/test/sqatt/src/Benchmarks/Sequence.hs
@@ -57,16 +57,17 @@ sequence10Ints = emptyExample
     , expectedResult = Pass
     }
 
-sequence10IntsCvc4 :: TxsExample
-sequence10IntsCvc4 = emptyExample
-    { exampleName = "sequence with a 10 integer channel (cvc4)"
-    , txsModelFiles = modelFiles
-    , txsCmdsFiles = [ seedSetupCmdFile
-                     , insqatt $ txsCmdPath BenchTest benchDir "Sequence10Ints"
-                     ]
-    , txsServerArgs = ["--smt-solver", "cvc4"]
-      , expectedResult = Pass
-    }
+-- cvc4 not currently supported.
+-- sequence10IntsCvc4 :: TxsExample
+-- sequence10IntsCvc4 = emptyExample
+--     { exampleName = "sequence with a 10 integer channel (cvc4)"
+--     , txsModelFiles = modelFiles
+--     , txsCmdsFiles = [ seedSetupCmdFile
+--                      , insqatt $ txsCmdPath BenchTest benchDir "Sequence10Ints"
+--                      ]
+--     , txsServerArgs = ["--smt-solver", "cvc4"]
+--       , expectedResult = Pass
+--     }
 
 sequence10IntsTD :: TxsExample
 sequence10IntsTD = emptyExample
@@ -83,6 +84,6 @@ benchmarksSet = TxsExampleSet "Sequence" [ do100Acts
                                          , do100IActs
                                          , do100DataActs
                                          , sequence10Ints
-                                         , sequence10IntsCvc4
+                                         --, sequence10IntsCvc4
                                          , sequence10IntsTD
                                          ]

--- a/test/sqatt/src/Benchmarks/Synchronization.hs
+++ b/test/sqatt/src/Benchmarks/Synchronization.hs
@@ -15,8 +15,8 @@ benchDir :: FilePath
 benchDir = "Synchronization"
 
 modelFiles :: [FilePath]
-modelFiles = [ txsFilePath BenchTest benchDir "Synchronization"
-             , txsFilePath BenchTest "Sequence" "SingleActionSequence"
+modelFiles = [ insqatt $ txsFilePath BenchTest benchDir "Synchronization"
+             , insqatt $ txsFilePath BenchTest "Sequence" "SingleActionSequence"
              ]
 
 do100Acts3procs :: TxsExample
@@ -24,7 +24,7 @@ do100Acts3procs = emptyExample
     { exampleName = "3 processes"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ForeverSynchronized3"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ForeverSynchronized3"
                      ]
     , expectedResult = Pass
     }
@@ -34,7 +34,7 @@ alternateTwoProcs = emptyExample
     { exampleName = "alternate 2 processes"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ForeverSyncAlt2"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ForeverSyncAlt2"
                      ]
     , expectedResult = Pass
     }
@@ -44,7 +44,7 @@ do100Acts3procsIStep = emptyExample
     { exampleName = "3 processes with internal action"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ForeverSynchronizedIStep3"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ForeverSynchronizedIStep3"
                      ]
     , expectedResult = Pass
     }
@@ -54,7 +54,7 @@ manySeqSync = emptyExample
     { exampleName = "6 sequential processes synchronizing in two actions"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "SyncAlternate6"
+                     , insqatt $ txsCmdPath BenchTest benchDir "SyncAlternate6"
                      ]
     , expectedResult = Pass
     }
@@ -64,7 +64,7 @@ manyActsSyncTop = emptyExample
     { exampleName = "many processes synchronizing at the top"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ManyActsSyncTop"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ManyActsSyncTop"
                      ]
     , expectedResult = Pass
     }
@@ -74,7 +74,7 @@ manySyncPairs = emptyExample
     { exampleName = "many processes synchronizing in pairs"
     , txsModelFiles = modelFiles
     , txsCmdsFiles = [ seedSetupCmdFile
-                     , txsCmdPath BenchTest benchDir "ManySyncPairs"
+                     , insqatt $ txsCmdPath BenchTest benchDir "ManySyncPairs"
                      ]
     , expectedResult = Pass
     }

--- a/test/sqatt/src/ExploreModels/All.hs
+++ b/test/sqatt/src/ExploreModels/All.hs
@@ -9,7 +9,8 @@ import qualified ExploreModels.ControlLoop          as ControlLoop
 import qualified ExploreModels.CustomersOrders      as CustomersOrders
 import qualified ExploreModels.DispatchProcess      as DispatchProcess
 import qualified ExploreModels.LuckyPeople          as LuckyPeople
-import qualified ExploreModels.MovingArms           as MovingArms
+-- Test disabled because it does not terminate. Tested on latest develop, v0.9 and v0.6, 7-9-24
+-- import qualified ExploreModels.MovingArms           as MovingArms
 import qualified ExploreModels.Queue                as Queue
 import qualified ExploreModels.ReadWriteConflict    as ReadWriteConflict
 import           Sqatt
@@ -19,7 +20,7 @@ allTests = [ ControlLoop.exampleSet
            , CustomersOrders.exampleSet
            , DispatchProcess.exampleSet
            , LuckyPeople.exampleSet
-           , MovingArms.exampleSet
+        --    , MovingArms.exampleSet
            , Queue.exampleSet
            , ReadWriteConflict.exampleSet
            ]

--- a/test/sqatt/src/Integration/ConfigFile.hs
+++ b/test/sqatt/src/Integration/ConfigFile.hs
@@ -6,7 +6,6 @@ See LICENSE at root directory of this repository.
 {-# LANGUAGE OverloadedStrings #-}
 module Integration.ConfigFile (testSet) where
 
-import           Data.Text          (Text)
 import qualified Data.Text          as T
 import           Prelude     hiding (FilePath)
 

--- a/test/sqatt/src/Paths.hs
+++ b/test/sqatt/src/Paths.hs
@@ -10,6 +10,7 @@ module Paths
     , ITest (ITest)
     , txsFilePath
     , txsCmdPath
+    , insqatt
     )
 where
 
@@ -55,3 +56,7 @@ txsCmdPath :: TestType a
            -> FilePath
 txsCmdPath tt currExampDir fp =
   dataDir tt </> currExampDir </> fromText fp <.> "txscmd"
+
+-- | Takes a relative path starting in the torxakis directory, and shifts it to the squatt folder
+insqatt :: FilePath -> FilePath
+insqatt p = "test" </> "sqatt" </> p

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -351,8 +351,7 @@ runTxsWithExample mLogDir ex delay = Concurrently $ do
     tErr = TestExpectationError $
               format ("Did not get expected result "%s)
                      (repr . expectedResult $ ex)
-    txsServerProc sLogDir args = Concurrently $
-      runInprocNI ((</> "txsserver.out.log") <$> sLogDir)  txsServerCmd args
+    txsServerProc sLogDir args = runInprocNI ((</> "txsserver.out.log") <$> sLogDir)  txsServerCmd args
 
 -- | Run a process.
 runInproc :: Maybe FilePath   -- ^ Directory where the logs will be stored, or @Nothing@ if no logging is desired.

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -438,9 +438,12 @@ getRandomPort = randomRIO (10000, 60000)
 -- | Check that the file exists.
 pathMustExist :: FilePath -> Test ()
 pathMustExist path =
-  unlessM (testpath path) (throwError sqattErr)
-  where sqattErr =
-          FilePathError $ format ("file "%s%" does not exists ") (repr path)
+  unlessM (testpath path) $ do
+    workingdirpath <- pwd
+    let workingdir = either id id $ toText workingdirpath
+    throwError (sqattErr workingdir)
+  where sqattErr dir =
+          FilePathError (format ("file "%s%" does not exists. Looking in working directory: "%s) (repr path) (repr dir))
 
 -- | Retrieve all the file paths from an example
 exampleInputFiles :: TxsExample -> [FilePath]

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -36,7 +36,7 @@ import           Control.Applicative
 import           Control.Arrow
 import           Control.Concurrent.Async
 import           Control.Exception
-import           Control.Foldl
+import           Control.Foldl hiding (either)
 import           Control.Monad.Except
 import           Control.Monad.Extra
 import           Criterion.Main

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -159,14 +159,14 @@ javacCmd = addExeSuffix "javac"
 -- In order to use these as a regular shell command, the arguments here must be given before any other arguments
 -- Needs to be kept up to date with the pattern matching format used in checkStackCommand, or be restructured to be less fragile.
 txsServerCmd :: Text
-txsServerCmd = "txsserver"
+txsServerCmd = addExeSuffix "txsserver"
 
 -- Run the torxakis version build from this repo, if it exists.
 -- Returns the command and list of needed arguments seperately.
 -- In order to use these as a regular shell command, the arguments here must be given before any other arguments
 -- Needs to be kept up to date with the pattern matching format used in checkStackCommand, or be restructured to be less fragile.
 txsUICmd :: Text
-txsUICmd = "torxakis"
+txsUICmd = addExeSuffix "torxakis"
 
 txsUILinePrefix :: Text
 txsUILinePrefix = "TXS >>  "
@@ -207,7 +207,7 @@ checkSMTSolvers :: IO ()
 checkSMTSolvers = 
   traverse_ checkCommand txsSupportedSolvers
   where
-    txsSupportedSolvers = Prelude.map addExeSuffix ["z3","cvc4"]
+    txsSupportedSolvers = Prelude.map addExeSuffix ["z3"]
 
 -- | Check that the given command exists in the search path of the host system.
 checkCommand :: Text -> IO ()
@@ -392,7 +392,7 @@ runTxsAsSut mLogDir modelFiles cmdsFile = do
   where
     txsUIProc imf port = Concurrently $
       let mCLogDir = (</> "txsui.SUT.out.log") <$> mLogDir in
-      runInproc mCLogDir (txsUICmd (port:imf) (input cmdsFile)
+      runInproc mCLogDir txsUICmd (port:imf) (input cmdsFile)
     txsServerProc port = Concurrently $
       let mCLogDir = (</> "txsserver.SUT.out.log") <$> mLogDir in
       runInprocNI mCLogDir  txsServerCmd [port]

--- a/test/sqatt/src/Sqatt.hs
+++ b/test/sqatt/src/Sqatt.hs
@@ -158,15 +158,15 @@ javacCmd = addExeSuffix "javac"
 -- Returns the command and list of needed arguments seperately.
 -- In order to use these as a regular shell command, the arguments here must be given before any other arguments
 -- Needs to be kept up to date with the pattern matching format used in checkStackCommand, or be restructured to be less fragile.
-txsServerCmd :: (Text, [Text])
-txsServerCmd = ("stack", ["exec", addExeSuffix "txsserver", "--"])
+txsServerCmd :: Text
+txsServerCmd = "txsserver"
 
 -- Run the torxakis version build from this repo, if it exists.
 -- Returns the command and list of needed arguments seperately.
 -- In order to use these as a regular shell command, the arguments here must be given before any other arguments
 -- Needs to be kept up to date with the pattern matching format used in checkStackCommand, or be restructured to be less fragile.
-txsUICmd :: (Text, [Text])
-txsUICmd = ("stack", ["exec", addExeSuffix "torxakis", "--"])
+txsUICmd :: Text
+txsUICmd = "torxakis"
 
 txsUILinePrefix :: Text
 txsUILinePrefix = "TXS >>  "
@@ -217,14 +217,6 @@ checkCommand cmd = do
     Nothing -> throwIO $ ProgramNotFound $ T.pack $ show cmd
     _       -> return ()
 
--- | Check that the given command wrapped by stack exec exists in the search path of the host system.
--- Takes List of arguments given to stack, with the assumption that this list follows the very specific format used in txsServerCmd and txsUICmd
--- Throws an Exception: ExitFailure 1 if the command is not found within the stack environment.
-checkStackCommand :: [Text] -> IO ()
-checkStackCommand ("exec":command:"--":_tl) = do
-  _ <- single $ inproc "stack" ("exec":"which":"--":[command]) Turtle.empty
-  return ()
-checkStackCommand _ = error "checkStackCommand called with invalid argument"
 -- | Check that all the compilers are installed.
 --
 -- Throws an exception on failure.
@@ -233,7 +225,7 @@ checkCompilers = traverse_ checkCommand [javaCmd, javacCmd]
 
 -- | Check that the TorXakis UI and server programs are installed.
 checkTxsInstall :: IO ()
-checkTxsInstall = traverse_ checkStackCommand [snd txsUICmd, snd txsServerCmd]
+checkTxsInstall = traverse_ checkCommand [txsUICmd, txsServerCmd]
 
 -- * Compilation and testing
 
@@ -342,13 +334,13 @@ runTxsWithExample mLogDir ex delay = Concurrently $ do
         txsUIShell =
             case mUiLogDir of
                 Nothing ->
-                    either id id <$> inprocWithErr (fst txsUICmd)
-                                                        (snd txsUICmd ++ (port:imf))
+                    either id id <$> inprocWithErr txsUICmd
+                                                        (port:imf)
                                                         inLines
                 Just uiLogDir -> do
                     h <- appendonly $ uiLogDir </> "txsui.out.log"
-                    line <- either id id <$> inprocWithErr (fst txsUICmd)
-                                                           (snd txsUICmd ++ (port:imf))
+                    line <- either id id <$> inprocWithErr txsUICmd
+                                                           (port:imf)
                                                            inLines
                     liftIO $ TIO.hPutStrLn h (lineToText line)
                     return line
@@ -360,7 +352,7 @@ runTxsWithExample mLogDir ex delay = Concurrently $ do
               format ("Did not get expected result "%s)
                      (repr . expectedResult $ ex)
     txsServerProc sLogDir args = Concurrently $
-      runInprocNI ((</> "txsserver.out.log") <$> sLogDir) (fst txsServerCmd) (snd txsServerCmd ++ args)
+      runInprocNI ((</> "txsserver.out.log") <$> sLogDir)  txsServerCmd args
 
 -- | Run a process.
 runInproc :: Maybe FilePath   -- ^ Directory where the logs will be stored, or @Nothing@ if no logging is desired.
@@ -400,10 +392,10 @@ runTxsAsSut mLogDir modelFiles cmdsFile = do
   where
     txsUIProc imf port = Concurrently $
       let mCLogDir = (</> "txsui.SUT.out.log") <$> mLogDir in
-      runInproc mCLogDir (fst txsUICmd) (snd txsUICmd ++ (port:imf)) (input cmdsFile)
+      runInproc mCLogDir (txsUICmd (port:imf) (input cmdsFile)
     txsServerProc port = Concurrently $
       let mCLogDir = (</> "txsserver.SUT.out.log") <$> mLogDir in
-      runInprocNI mCLogDir (fst txsServerCmd) ((snd txsServerCmd)++[port])
+      runInprocNI mCLogDir  txsServerCmd [port]
 
 mkTest :: Maybe FilePath -> RunnableExample -> Test ()
 mkTest mLogDir (ExampleWithSut ex cSUT args) = do

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -13,7 +13,7 @@
 # to be used for project dependencies. For example:
 #
 # needed for cache space: same as torxakis
-resolver: lts-11.22
+resolver: lts-18.28
 ghc-variant: integersimple
 
 # User packages to be built.

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -41,9 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 
 # Override default flag values for local packages and extra-deps
-flags: 
-  text: 
-    integer-simple: true
+flags:
   hashable:
     integer-gmp: false
   integer-logarithms:

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -10,9 +10,10 @@
 
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
-# to be used for project dependencies. For example:
+# to be used for project dependencies.
 #
 # needed for cache space: same as torxakis
+# Note: This has to manually be kept up to date with the resolver version in the main stack.yaml file, or the test results might not match with the release build.
 resolver: lts-18.28
 ghc-variant: integersimple
 

--- a/test/sqatt/stack.yaml
+++ b/test/sqatt/stack.yaml
@@ -15,8 +15,6 @@
 # needed for cache space: same as torxakis
 # Note: This has to manually be kept up to date with the resolver version in the main stack.yaml file, or the test results might not match with the release build.
 resolver: lts-18.28
-ghc-variant: integersimple
-
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #
@@ -39,15 +37,6 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-
-# Override default flag values for local packages and extra-deps
-flags:
-  hashable:
-    integer-gmp: false
-  integer-logarithms:
-    integer-gmp: false
-  scientific:
-    integer-simple: true
 
 # Extra package databases containing global packages
 extra-package-dbs:

--- a/test/sqatt/stack.yaml.lock
+++ b/test/sqatt/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 527836
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/22.yaml
-    sha256: 341870ac98d8a9f8f77c4adf2e9e0b22063e264a7fbeb4c85b7af5f380dac60e
-  original: lts-11.22
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28

--- a/test/sqatt/stack_linux.yaml
+++ b/test/sqatt/stack_linux.yaml
@@ -12,14 +12,10 @@
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:
 #
-# resolver: lts-3.5
-# resolver: nightly-2015-09-21
-# resolver: ghc-7.10.2
-# resolver: ghcjs-0.1.0_ghc-7.10.2
-# resolver:
-#  name: custom-snapshot
-#  location: "./custom-snapshot.yaml"
-resolver: lts-11.22
+# needed for cache space: same as torxakis
+# NOTE: This has to manually be kept up to date with the resolver used in the main stack.yaml file.
+resolver: lts-18.28
+ghc-variant: integersimple
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/sqatt/stack_linux.yaml
+++ b/test/sqatt/stack_linux.yaml
@@ -15,8 +15,6 @@
 # needed for cache space: same as torxakis
 # NOTE: This has to manually be kept up to date with the resolver used in the main stack.yaml file.
 resolver: lts-18.28
-ghc-variant: integersimple
-
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/test/sqatt/test/Benchmarks/TestBenchmarksSanity.hs
+++ b/test/sqatt/test/Benchmarks/TestBenchmarksSanity.hs
@@ -15,5 +15,5 @@ main :: IO ()
 main = do
     cd $ ".." </> ".."
     logDir <- mkLogDir "benchmarks-test-"
-    cd $ "test" </> "sqatt"
-    hspec $ parallel $ testExampleSets (".." </> ".." </> logDir) allExamples
+    -- cd $ "test" </> "sqatt"
+    hspec $ parallel $ testExampleSets (logDir) allExamples

--- a/test/sqatt/test/Benchmarks/TestBenchmarksSanity.hs
+++ b/test/sqatt/test/Benchmarks/TestBenchmarksSanity.hs
@@ -16,4 +16,6 @@ main = do
     cd $ ".." </> ".."
     logDir <- mkLogDir "benchmarks-test-"
     -- cd $ "test" </> "sqatt"
-    hspec $ parallel $ testExampleSets (logDir) allExamples
+    --parallel causes nondeterministic crashes. Removed until it can be fixed.
+    --hspec $ parallel $ testExampleSets (logDir) allExamples
+    hspec $ testExampleSets (logDir) allExamples

--- a/test/sqatt/test/Examples/AllSpec.hs
+++ b/test/sqatt/test/Examples/AllSpec.hs
@@ -14,13 +14,13 @@ import           Test.Hspec
 
 spec :: Spec
 spec = beforeAll
-         ( do checkSMTSolvers
+         ( do cd $ ".." </> ".."
+              checkSMTSolvers
               checkCompilers
               checkTxsInstall
               hSetBuffering System.IO.stdout NoBuffering
          )
          ( do
-             runIO $ cd $ ".." </> ".."
              logDir <- runIO $ mkLogDir "test-"
              testExampleSets logDir allExamples
          )

--- a/test/sqatt/test/ExploreModels/ExploreModels.hs
+++ b/test/sqatt/test/ExploreModels/ExploreModels.hs
@@ -12,4 +12,4 @@ main :: IO ()
 main = do
     cd $ ".." </> ".."
     logDir <- mkLogDir "explore-model-test-"
-    hspec $ parallel $ testExampleSets logDir allTests
+    hspec $ testExampleSets logDir allTests

--- a/test/sqatt/test/Integration/Main.hs
+++ b/test/sqatt/test/Integration/Main.hs
@@ -11,4 +11,7 @@ import           Test.Hspec
 main :: IO ()
 main = do
     logDir <- mkLogDir "integration-test-"
-    hspec $ parallel $ testExampleSets logDir allTests
+    --parallel causes nondeterministic crashes. Removed until it can be fixed.
+    --hspec $ parallel $ testExampleSets logDir allTests
+    hspec  $ testExampleSets logDir allTests
+


### PR DESCRIPTION
Updates the LTS version used by the project, allowing the use of newer libraries, and the [haskell-language-server implementation of the LSP](https://github.com/haskell/haskell-language-server) for IDE support while developing.